### PR TITLE
WIP some SVGView improvements

### DIFF
--- a/tools/viewsvg/mainwindow.ui
+++ b/tools/viewsvg/mainwindow.ui
@@ -15,14 +15,8 @@
   </property>
   <widget class="QWidget" name="centralWidget">
    <layout class="QVBoxLayout" name="verticalLayout_2">
-    <property name="spacing">
-     <number>6</number>
-    </property>
     <property name="leftMargin">
      <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>6</number>
     </property>
     <property name="rightMargin">
      <number>0</number>
@@ -33,7 +27,7 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
-       <number>2</number>
+       <number>6</number>
       </property>
       <item>
        <widget class="QLabel" name="label_3">
@@ -151,10 +145,10 @@
        </sizepolicy>
       </property>
       <property name="frameShape">
-       <enum>QFrame::StyledPanel</enum>
+       <enum>QFrame::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Sunken</enum>
+       <enum>QFrame::Plain</enum>
       </property>
      </widget>
     </item>

--- a/tools/viewsvg/svgview.cpp
+++ b/tools/viewsvg/svgview.cpp
@@ -5,16 +5,13 @@
 #include <QPainter>
 #include <QThread>
 #include <QTimer>
-#include <QWindow>
 
 #include "svgview.h"
 
-SvgViewWorker::SvgViewWorker(QWidget *parent)
+SvgViewWorker::SvgViewWorker(QObject *parent, const float dpi)
     : QObject(parent)
-    , m_window(parent->windowHandle())
-    , m_dpiRatio(qApp->primaryScreen()->devicePixelRatio())
+    , m_dpiRatio(dpi)
 {
-    connect(m_window, &QWindow::screenChanged, this, &SvgViewWorker::setScreenDPI);
 }
 
 QRect SvgViewWorker::viewBox() const
@@ -45,11 +42,6 @@ QString SvgViewWorker::loadFile(const QString &path)
     }
 
     return QString();
-}
-
-void SvgViewWorker::setScreenDPI(const QScreen *screen)
-{
-    m_dpiRatio = screen->devicePixelRatio();
 }
 
 void SvgViewWorker::render(const QSize &viewSize)
@@ -95,7 +87,7 @@ static QImage genCheckedTexture()
 SvgView::SvgView(QWidget *parent)
     : QFrame(parent)
     , m_checkboardImg(genCheckedTexture())
-    , m_worker(new SvgViewWorker(this))
+    , m_worker(new SvgViewWorker())
     , m_resizeTimer(new QTimer(this))
 {
     setAcceptDrops(true);

--- a/tools/viewsvg/svgview.h
+++ b/tools/viewsvg/svgview.h
@@ -11,7 +11,7 @@ class SvgViewWorker : public QObject
     Q_OBJECT
 
 public:
-    SvgViewWorker(QWidget *parent = nullptr);
+    SvgViewWorker(QObject *parent = nullptr, const float dpi = qApp->primaryScreen()->devicePixelRatio());
 
     QRect viewBox() const;
 
@@ -20,15 +20,11 @@ public slots:
     QString loadFile(const QString &path);
     void render(const QSize &viewSize);
 
-private slots:
-    void setScreenDPI(const QScreen *screen);
-
 signals:
     void rendered(QImage);
 
 private:
-    const QWindow *m_window;
-    mutable double m_dpiRatio;
+    const float m_dpiRatio;
     mutable QMutex m_mutex;
     ResvgRenderer m_renderer;
 };

--- a/tools/viewsvg/svgview.h
+++ b/tools/viewsvg/svgview.h
@@ -11,7 +11,7 @@ class SvgViewWorker : public QObject
     Q_OBJECT
 
 public:
-    SvgViewWorker(QObject *parent = nullptr);
+    SvgViewWorker(QWidget *parent = nullptr);
 
     QRect viewBox() const;
 
@@ -20,11 +20,15 @@ public slots:
     QString loadFile(const QString &path);
     void render(const QSize &viewSize);
 
+private slots:
+    void setScreenDPI(const QScreen *screen);
+
 signals:
     void rendered(QImage);
 
 private:
-    const float m_dpiRatio;
+    const QWindow *m_window;
+    mutable double m_dpiRatio;
     mutable QMutex m_mutex;
     ResvgRenderer m_renderer;
 };


### PR DESCRIPTION
I improved the look and added code to use the actual screen’s DPI.

Sadly I’m not very good in C++, so it crashes. I guess the fact that I bring in references to the QWindow in from its thread into the worker thread is a problem?

In that case we can go another route, e.g. storing it at a fixed memory location, or going over events.