### PR TITLE
[WIP] PoC of resvg-convert (rsvg-convert like tool)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,11 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "c_vec"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cairo-example"
 version = "0.1.0"
 dependencies = [
@@ -529,7 +534,9 @@ dependencies = [
 name = "resvg"
 version = "0.6.1"
 dependencies = [
+ "c_vec 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cairo-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cairo-sys-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gdk-pixbuf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pango 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,6 +554,17 @@ dependencies = [
  "fern 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "resvg 0.6.1",
+]
+
+[[package]]
+name = "resvg-convert"
+version = "0.6.1"
+dependencies = [
+ "fern 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "resvg 0.6.1",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -697,6 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum c_vec 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c32b15e95ce816aaf991a41420854e6ba772a2679a9296d906eab1114f1b4e9"
 "checksum cairo-rs 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e09d8a818b2ccc8983f04d95a9350c3cf8d24cc456cedca3b88fa3a81fdc0e2"
 "checksum cairo-sys-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3fa13914fdc013387afa771f554f2f71d6ae931f4e5be9246c337d60c3dc484"
 "checksum cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["multimedia::images"]
 members = [
     "capi",
     "tools/rendersvg",
+    "tools/resvg-convert",
     "tools/usvg",
     "examples/cairo-rs",
     "usvg",
@@ -27,9 +28,11 @@ travis-ci = { repository = "RazrFalcon/resvg" }
 log = "0.4"
 rgb = "0.8"
 usvg = { path = "usvg", version = "0.6" }
+c_vec = "^1.0.0"
 
 # cairo backend
-cairo-rs = { version = "0.6", features = ["png"], optional = true }
+cairo-rs = { version = "0.6", features = ["png", "svg", "pdf"], optional = true }
+cairo-sys-rs = { version = "0.8.0", optional = true }
 gdk-pixbuf = { version = "0.6", optional = true }
 pango = { version = "0.6", optional = true }
 pangocairo = { version = "0.7", optional = true }
@@ -38,7 +41,7 @@ pangocairo = { version = "0.7", optional = true }
 resvg-qt = { path = "resvg-qt", version = "0.6", optional = true }
 
 [features]
-cairo-backend = ["cairo-rs", "gdk-pixbuf", "pango", "pangocairo"]
+cairo-backend = ["cairo-rs", "cairo-sys-rs", "gdk-pixbuf", "pango", "pangocairo"]
 qt-backend = ["resvg-qt"]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ usvg = { path = "usvg", version = "0.6" }
 c_vec = "^1.0.0"
 
 # cairo backend
-cairo-rs = { version = "0.6", features = ["png", "svg", "pdf"], optional = true }
+cairo-rs = { version = "0.6", features = ["png", "svg", "pdf", "ps"], optional = true }
 cairo-sys-rs = { version = "0.8.0", optional = true }
 gdk-pixbuf = { version = "0.6", optional = true }
 pango = { version = "0.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ And as an embeddable library to paint SVG on an application native canvas.
 #[macro_use] pub extern crate usvg;
 #[macro_use] extern crate log;
 extern crate rgb;
+extern crate c_vec;
 
 #[cfg(feature = "cairo-backend")] pub extern crate cairo;
 #[cfg(feature = "cairo-backend")] extern crate pango;
@@ -48,6 +49,8 @@ mod geom;
 mod layers;
 mod options;
 mod traits;
+
+use std::io::Write;
 
 /// Commonly used types and traits.
 pub mod prelude {
@@ -77,6 +80,12 @@ mod short {
     };
 }
 
+/// Specifies types for image rendering
+pub enum RenderFormat {
+    SVG,
+    PNG,
+    PDF,
+}
 
 /// A generic interface for image rendering.
 ///
@@ -100,6 +109,15 @@ pub trait Render {
         node: &usvg::Node,
         opt: &Options,
     ) -> Option<Box<OutputImage>>;
+
+    /// Renders SVG node to data stream
+    fn render_to_stream(
+        &self,
+        tree: &usvg::Tree,
+        opt: &Options,
+        format: RenderFormat,
+        writer: &mut dyn Write
+    ) -> bool;
 
     /// Calculates node's absolute bounding box.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ pub enum RenderFormat {
     SVG,
     PNG,
     PDF,
+    EPS,
+    PS,
 }
 
 /// A generic interface for image rendering.
@@ -110,10 +112,19 @@ pub trait Render {
         opt: &Options,
     ) -> Option<Box<OutputImage>>;
 
-    /// Renders SVG node to data stream
+    /// Renders SVG tree to data stream
     fn render_to_stream(
         &self,
         tree: &usvg::Tree,
+        opt: &Options,
+        format: RenderFormat,
+        writer: &mut dyn Write
+    ) -> bool;
+
+    /// Renders SVG node to data stream
+    fn render_node_to_stream(
+        &self,
+        node: &usvg::Node,
         opt: &Options,
         format: RenderFormat,
         writer: &mut dyn Write

--- a/tools/resvg-convert/.gitignore
+++ b/tools/resvg-convert/.gitignore
@@ -1,0 +1,3 @@
+/*.svg
+/*.png
+/callgrind.out.*

--- a/tools/resvg-convert/Cargo.toml
+++ b/tools/resvg-convert/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "resvg-convert"
+version = "0.6.1"
+authors = ["Damian Kaczmarek <rush@rushbase.net>"]
+keywords = ["svg", "render", "raster"]
+license = "MPL-2.0"
+workspace = "../../"
+
+[dependencies]
+fern = "0.5"
+gumdrop = "0.5"
+log = "0.4"
+resvg = { path = "../../" }
+time = "0.1"
+
+[features]
+cairo-backend = ["resvg/cairo-backend"]
+

--- a/tools/resvg-convert/LICENSE.txt
+++ b/tools/resvg-convert/LICENSE.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/tools/resvg-convert/README.md
+++ b/tools/resvg-convert/README.md
@@ -1,0 +1,20 @@
+# rendersvg
+
+*rendersvg* is an [SVG](https://en.wikipedia.org/wiki/Scalable_Vector_Graphics) rendering application.
+
+## Build
+
+```bash
+# Build with a Qt backend
+cargo build --release --features="qt-backend"
+# or with a cairo backend
+cargo build --release --features="cairo-backend"
+# or with both.
+cargo build --release --features="qt-backend cairo-backend"
+```
+
+See [BUILD.adoc](../../BUILD.adoc) for details.
+
+## License
+
+*rendersvg* is licensed under the [MPLv2.0](https://www.mozilla.org/en-US/MPL/).

--- a/tools/resvg-convert/src/args.rs
+++ b/tools/resvg-convert/src/args.rs
@@ -211,7 +211,7 @@ fn parse_languages(s: &str) -> Result<Vec<String>, &'static str> {
 }
 
 pub struct Args {
-    pub in_svg: path::PathBuf,
+    pub in_svg: String,
     pub out_file: String,
     pub out_format: String,
     pub backend_name: String,
@@ -240,14 +240,7 @@ pub fn parse() -> Result<(Args, resvg::Options), String> {
         process::exit(0);
     }
 
-    let positional_count = 1;
-
-    if args.free.len() != positional_count {
-        return Err(format!("<in-svg>"));
-    }
-
-    let in_svg: path::PathBuf = args.free[0].to_string().into();
-
+    let in_svg = if args.free.len() > 0 { args.free[0].to_string() } else { String::from("-") };
     let out_file = args.output.unwrap_or(String::from("-"));
     let backend_name = args.backend.unwrap_or(default_backend().to_string());
     let dump = args.dump_svg.map(|v| v.into());

--- a/tools/resvg-convert/src/args.rs
+++ b/tools/resvg-convert/src/args.rs
@@ -1,0 +1,341 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// We don't use `clap` to reduce executable size.
+
+use std::process;
+use std::path;
+
+use gumdrop::Options;
+
+use resvg::{
+    self,
+    usvg,
+    FitTo,
+};
+
+pub fn print_help() {
+    print!("\
+rendersvg is an SVG rendering application.
+
+USAGE:
+    rendersvg [OPTIONS] <in-svg> <out-png>
+
+    rendersvg in.svg out.png
+    rendersvg -z 4 in.svg out.png
+    rendersvg --query-all in.svg
+
+OPTIONS:
+        --help                  Prints help information
+    -V, --version               Prints version information
+
+        --backend BACKEND       Sets the rendering backend.
+                                Has no effect if built with only one backend
+                                [default: {}] [possible values: {}]
+    -f, --format FORMAT         Save format
+                                [default: {} [possible values: {}]
+    -o, --output                Output filename [optional: defaults to stdout]
+    -w, --width LENGTH          Sets the width in pixels
+    -h, --height LENGTH         Sets the height in pixels
+    -z, --zoom FACTOR           Zooms the image by a factor
+        --dpi DPI               Sets the resolution
+                                [default: 96] [possible values: 10..4000]
+
+        --background COLOR      Sets the background color.
+                                Examples: red, #fff, #fff000
+        --font-family FAMILY    Sets the default font family
+                                [default: 'Times New Roman']
+        --font-size SIZE        Sets the default font size
+                                [default: 12] [possible values: 1..192]
+        --languages LANG        Sets a comma-separated list of languages that
+                                will be used during the 'systemLanguage'
+                                attribute resolving.
+                                Examples: 'en-US', 'en-US, ru-RU', 'en, ru'
+                                [default: 'en']
+        --shape-rendering HINT  Selects the default shape rendering method.
+                                [default: geometricPrecision]
+                                [possible values: optimizeSpeed, crispEdges,
+                                geometricPrecision]
+        --text-rendering HINT   Selects the default text rendering method.
+                                [default: optimizeLegibility]
+                                [possible values: optimizeSpeed,
+                                optimizeLegibility, geometricPrecision]
+        --image-rendering HINT  Selects the default image rendering method.
+                                [default: optimizeQuality]
+                                [possible values: optimizeQuality,
+                                optimizeSpeed]
+
+        --query-all             Queries all valid SVG ids with bounding boxes
+        --export-id ID          Renders an object only with a specified ID
+
+        --perf                  Prints performance stats
+        --pretend               Does all the steps except rendering
+        --quiet                 Disables warnings
+        --dump-svg <PATH>       Saves the preprocessed SVG to the selected file
+
+ARGS:
+    <in-svg>                    Input file
+", default_backend(), backends().join(", "),
+   "svg", formats().join(", ")
+   );
+}
+
+#[derive(Debug, Options)]
+struct CliArgs {
+    #[options(no_short)]
+    help: bool,
+
+    #[options(short = "V")]
+    version: bool,
+
+    #[options(no_short, meta = "BACKEND")]
+    backend: Option<String>,
+
+    #[options(short ="f", meta = "FORMAT")]
+    out_format: Option<String>,
+
+    #[options(short ="o", meta = "FORMAT")]
+    output: Option<String>,
+
+    #[options(short = "w", meta = "LENGTH", parse(try_from_str = "parse_length"))]
+    width: Option<u32>,
+
+    #[options(short = "h", meta = "LENGTH", parse(try_from_str = "parse_length"))]
+    height: Option<u32>,
+
+    #[options(short = "z", meta = "ZOOM", parse(try_from_str = "parse_zoom"))]
+    zoom: Option<f32>,
+
+    #[options(no_short, meta = "DPI", default = "96", parse(try_from_str = "parse_dpi"))]
+    dpi: u32,
+
+    #[options(no_short, meta = "COLOR", parse(try_from_str = "parse_color"))]
+    background: Option<usvg::Color>,
+
+    #[options(no_short, meta = "FAMILY", default = "Times New Roman")]
+    font_family: String,
+
+    #[options(no_short, meta = "SIZE", default = "12", parse(try_from_str = "parse_font_size"))]
+    font_size: u32,
+
+    #[options(no_short, meta = "LANG", parse(try_from_str = "parse_languages"))]
+    languages: Option<Vec<String>>,
+
+    #[options(no_short, meta = "HINT", default = "geometricPrecision", parse(try_from_str))]
+    shape_rendering: usvg::ShapeRendering,
+
+    #[options(no_short, meta = "HINT", default = "optimizeLegibility", parse(try_from_str))]
+    text_rendering: usvg::TextRendering,
+
+    #[options(no_short, meta = "HINT", default = "optimizeQuality", parse(try_from_str))]
+    image_rendering: usvg::ImageRendering,
+
+    #[options(no_short)]
+    query_all: bool,
+
+    #[options(no_short, meta = "ID")]
+    export_id: Option<String>,
+
+    #[options(no_short)]
+    perf: bool,
+
+    #[options(no_short)]
+    pretend: bool,
+
+    #[options(no_short)]
+    quiet: bool,
+
+    #[options(no_short, meta = "PATH")]
+    dump_svg: Option<String>,
+
+    #[options(free)]
+    free: Vec<String>,
+}
+
+fn parse_color(s: &str) -> Result<usvg::Color, &'static str> {
+    s.parse().map_err(|_| "invalid zoom factor")
+}
+
+fn parse_dpi(s: &str) -> Result<u32, &'static str> {
+    let n: u32 = s.parse().map_err(|_| "invalid number")?;
+
+    if n >= 10 && n <= 4000 {
+        Ok(n)
+    } else {
+        Err("DPI out of bounds")
+    }
+}
+
+fn parse_length(s: &str) -> Result<u32, &'static str> {
+    let n: u32 = s.parse().map_err(|_| "invalid length")?;
+
+    if n > 0 {
+        Ok(n)
+    } else {
+        Err("LENGTH cannot be zero")
+    }
+}
+
+fn parse_zoom(s: &str) -> Result<f32, &'static str> {
+    let n: f32 = s.parse().map_err(|_| "invalid zoom factor")?;
+
+    if n > 0.0 {
+        Ok(n)
+    } else {
+        Err("ZOOM should be positive")
+    }
+}
+
+fn parse_font_size(s: &str) -> Result<u32, &'static str> {
+    let n: u32 = s.parse().map_err(|_| "invalid number")?;
+
+    if n > 0 && n <= 192 {
+        Ok(n)
+    } else {
+        Err("font size out of bounds")
+    }
+}
+
+fn parse_languages(s: &str) -> Result<Vec<String>, &'static str> {
+    let mut langs = Vec::new();
+    for lang in s.split(',') {
+        langs.push(lang.trim().to_string());
+    }
+
+    if langs.is_empty() {
+        return Err("languages list cannot be empty");
+    }
+
+    Ok(langs)
+}
+
+pub struct Args {
+    pub in_svg: path::PathBuf,
+    pub out_file: String,
+    pub out_format: String,
+    pub backend_name: String,
+    pub query_all: bool,
+    pub export_id: Option<String>,
+    pub dump: Option<path::PathBuf>,
+    pub pretend: bool,
+    pub perf: bool,
+    pub quiet: bool,
+}
+
+pub fn parse() -> Result<(Args, resvg::Options), String> {
+    let args: Vec<String> = ::std::env::args().collect();
+    let args = match CliArgs::parse_args_default(&args[1..]) {
+        Ok(v) => v,
+        Err(e) => return Err(format!("{}", e)),
+    };
+
+    if args.help {
+        print_help();
+        process::exit(0);
+    }
+
+    if args.version {
+        println!("{}", env!("CARGO_PKG_VERSION"));
+        process::exit(0);
+    }
+
+    let positional_count = 1;
+
+    if args.free.len() != positional_count {
+        return Err(format!("<in-svg>"));
+    }
+
+    let in_svg: path::PathBuf = args.free[0].to_string().into();
+
+    let out_file = args.output.unwrap_or(String::from("-"));
+    let backend_name = args.backend.unwrap_or(default_backend().to_string());
+    let dump = args.dump_svg.map(|v| v.into());
+    let export_id = args.export_id.map(|v| v.to_string());
+    let out_format = args.out_format.unwrap_or(default_format().to_string());
+
+    let app_args = Args {
+        in_svg: in_svg.clone(),
+        out_format,
+        out_file,
+        backend_name,
+        query_all: args.query_all,
+        export_id,
+        dump,
+        pretend: args.pretend,
+        perf: args.perf,
+        quiet: args.quiet,
+    };
+
+    // We don't have to keep named groups when we don't need them
+    // because it will slow down rendering.
+    let keep_named_groups = app_args.query_all || app_args.export_id.is_some();
+
+    let mut fit_to = FitTo::Original;
+    if let Some(w) = args.width {
+        fit_to = FitTo::Width(w);
+    } else if let Some(h) = args.height {
+        fit_to = FitTo::Height(h);
+    } else if let Some(z) = args.zoom {
+        fit_to = FitTo::Zoom(z);
+    }
+
+    let languages = match args.languages.as_ref() {
+        Some(v) => v.clone(),
+        None => vec!["en".to_string()], // TODO: use system language
+    };
+
+    let opt = resvg::Options {
+        usvg: usvg::Options {
+            path: Some(in_svg.into()),
+            dpi: args.dpi as f64,
+            font_family: args.font_family.clone(),
+            font_size: args.font_size as f64,
+            languages,
+            shape_rendering: args.shape_rendering,
+            text_rendering: args.text_rendering,
+            image_rendering: args.image_rendering,
+            keep_named_groups,
+        },
+        fit_to,
+        background: args.background,
+    };
+
+    Ok((app_args, opt))
+}
+
+#[allow(unreachable_code)]
+fn default_backend() -> &'static str {
+    #[cfg(feature = "cairo-backend")]
+    { return "cairo" }
+
+    #[cfg(feature = "qt-backend")]
+    { return "qt" }
+
+    unreachable!();
+}
+
+fn backends() -> Vec<&'static str> {
+    let mut list = Vec::new();
+
+    #[cfg(feature = "cairo-backend")]
+    { list.push("cairo"); }
+
+    #[cfg(feature = "qt-backend")]
+    { list.push("qt"); }
+
+    list
+}
+
+fn default_format() -> &'static str {
+    return "svg";
+}
+
+fn formats() -> Vec<&'static str> {
+    let mut list = Vec::new();
+
+    { list.push("svg"); }
+    { list.push("pdf"); }
+
+    list
+}

--- a/tools/resvg-convert/src/main.rs
+++ b/tools/resvg-convert/src/main.rs
@@ -1,0 +1,226 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#[allow(unused_imports)] // for Rust >= 1.30
+#[macro_use]
+extern crate gumdrop;
+
+extern crate fern;
+extern crate log;
+extern crate resvg;
+extern crate time;
+
+
+use std::fmt;
+use std::fs::{File};
+use std::io::{self, Write};
+use std::path;
+
+use resvg::prelude::*;
+use resvg::svgdom;
+use resvg::RenderFormat;
+
+use svgdom::WriteBuffer;
+
+mod args;
+
+
+macro_rules! bail {
+    ($msg:expr) => {
+        return Err(format!("{}", $msg));
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return Err(format!($fmt, $($arg)*));
+    };
+}
+
+
+fn main() {
+    if let Err(e) = process() {
+        eprintln!("Error: {}.", e);
+        std::process::exit(1);
+    }
+}
+
+fn process() -> Result<(), String> {
+    #[cfg(all(not(feature = "cairo-backend"), not(feature = "qt-backend")))]
+    {
+        bail!("rendersvg has been built without any backends")
+    }
+
+    let (args, opt) = match args::parse() {
+        Ok((args, opt)) => (args, opt),
+        Err(e) => {
+            args::print_help();
+            println!();
+            bail!(e)
+        }
+    };
+
+    // Do not print warning during the ID querying.
+    //
+    // Some crates still can print to stdout/stderr, but we can't do anything about it.
+    if !(args.query_all || args.quiet) {
+        fern::Dispatch::new()
+            .format(log_format)
+            .level(log::LevelFilter::Warn)
+            .chain(std::io::stderr())
+            .apply().unwrap();
+    }
+
+    let backend: Box<Render> = match args.backend_name.as_str() {
+        #[cfg(feature = "cairo-backend")]
+        "cairo" => Box::new(resvg::backend_cairo::Backend),
+        _ => bail!("unknown backend"),
+    };
+
+    macro_rules! timed {
+        ($name:expr, $task:expr) => { run_task(args.perf, $name, || $task) };
+    }
+
+    // Load file.
+    let tree = timed!("Preprocessing", {
+        usvg::Tree::from_file(&args.in_svg, &opt.usvg).map_err(|e| e.to_string())
+    })?;
+
+    if args.query_all {
+        return query_all(backend, &tree, &opt);
+    }
+
+    // Dump before rendering in case of panic.
+    if let Some(ref dump_path) = args.dump {
+        dump_svg(&tree, dump_path)?;
+    }
+
+    if args.pretend {
+        return Ok(());
+    }
+
+    let format = match args.out_format.as_ref() {
+        "svg" => RenderFormat::SVG,
+        "pdf" => RenderFormat::PDF,
+        "png" => RenderFormat::PNG,
+        "eps" => RenderFormat::EPS,
+        "ps" => RenderFormat::PS,
+        _ => bail!("unknown format"),
+    };
+
+    if args.out_file.eq("-") {
+        let mut stream = io::stdout();
+        stream.lock();
+        if let Some(ref id) = args.export_id {
+            if let Some(node) = tree.root().descendants().find(|n| &*n.id() == id) {
+                timed!("Rendering", backend.render_node_to_stream(&node, &opt, format, &mut stream));
+            } else {
+                bail!("SVG doesn't have '{}' ID", id)
+            }
+        } else {
+            timed!("Rendering", backend.render_to_stream(&tree, &opt, format, &mut stream));
+        }
+    } else {
+        let mut file = File::create(args.out_file).expect("Cannot create file for writing");
+        if let Some(ref id) = args.export_id {
+            if let Some(node) = tree.root().descendants().find(|n| &*n.id() == id) {
+                timed!("Rendering", backend.render_node_to_stream(&node, &opt, format, &mut file));
+            } else {
+                bail!("SVG doesn't have '{}' ID", id)
+            }
+        } else {
+            timed!("Rendering", backend.render_to_stream(&tree, &opt, format, &mut file));
+        }
+    };
+
+    Ok(())
+}
+
+fn query_all(
+    backend: Box<Render>,
+    tree: &usvg::Tree,
+    opt: &Options,
+) -> Result<(), String> {
+    let mut count = 0;
+    for node in tree.root().descendants() {
+        if tree.is_in_defs(&node) {
+            continue;
+        }
+
+        if node.id().is_empty() {
+            continue;
+        }
+
+        count += 1;
+
+        fn round_len(v: f64) -> f64 {
+            (v * 1000.0).round() / 1000.0
+        }
+
+        if let Some(bbox) = backend.calc_node_bbox(&node, &opt) {
+            println!("{},{},{},{},{}", node.id(),
+                     round_len(bbox.x), round_len(bbox.y),
+                     round_len(bbox.width), round_len(bbox.height));
+        }
+    }
+
+    if count == 0 {
+        bail!("the file has no valid ID's");
+    }
+
+    Ok(())
+}
+
+fn run_task<P, T>(perf: bool, title: &str, p: P) -> T
+    where P: FnOnce() -> T
+{
+    if perf {
+        let start = time::precise_time_ns();
+        let res = p();
+        let end = time::precise_time_ns();
+        println!("{}: {:.2}ms", title, (end - start) as f64 / 1_000_000.0);
+        res
+    } else {
+        p()
+    }
+}
+
+fn dump_svg(tree: &usvg::Tree, path: &path::Path) -> Result<(), String> {
+    let mut f = File::create(path)
+                   .map_err(|_| format!("failed to create a file {:?}", path))?;
+
+    let opt = svgdom::WriteOptions {
+        indent: svgdom::Indent::Spaces(2),
+        attributes_indent: svgdom::Indent::Spaces(3),
+        attributes_order: svgdom::AttributesOrder::Specification,
+        .. svgdom::WriteOptions::default()
+    };
+
+    let svgdoc = tree.to_svgdom();
+
+    let mut out = Vec::new();
+    svgdoc.write_buf_opt(&opt, &mut out);
+    f.write_all(&out).map_err(|_| format!("failed to write a file {:?}", path))?;
+
+    Ok(())
+}
+
+fn log_format(
+    out: fern::FormatCallback,
+    message: &fmt::Arguments,
+    record: &log::Record,
+) {
+    let lvl = match record.level() {
+        log::Level::Error => "Error",
+        log::Level::Warn  => "Warning",
+        log::Level::Info  => "Info",
+        log::Level::Debug => "Debug",
+        log::Level::Trace => "Trace",
+    };
+
+    out.finish(format_args!(
+        "{} (in {}:{}): {}",
+        lvl,
+        record.target(),
+        record.line().unwrap_or(0),
+        message
+    ))
+}

--- a/tools/resvg-convert/src/main.rs
+++ b/tools/resvg-convert/src/main.rs
@@ -14,7 +14,7 @@ extern crate time;
 
 use std::fmt;
 use std::fs::{File};
-use std::io::{self, Write};
+use std::io::{self, Write, Read};
 use std::path;
 
 use resvg::prelude::*;
@@ -80,9 +80,19 @@ fn process() -> Result<(), String> {
     }
 
     // Load file.
-    let tree = timed!("Preprocessing", {
-        usvg::Tree::from_file(&args.in_svg, &opt.usvg).map_err(|e| e.to_string())
-    })?;
+    let tree = if !args.in_svg.eq("-") {
+        timed!("Preprocessing", {
+            usvg::Tree::from_file(&args.in_svg, &opt.usvg)
+                .map_err(|e| e.to_string())
+        })?
+    } else {
+        let mut buffer = String::new();
+        io::stdin().read_to_string(&mut buffer).expect("Cannot read string");
+        timed!("Preprocessing", {
+            usvg::Tree::from_str(&buffer, &opt.usvg)
+                    .map_err(|e| e.to_string())
+        })?
+    };
 
     if args.query_all {
         return query_all(backend, &tree, &opt);


### PR DESCRIPTION
**NOTE: This is my first ever written Rust code - I won't lie, a lot of it was trial and error**

What is working (and is working well):
- Output to STDOUT `resvg-convert in.svg -f png`
- Conversion to SVG with text converted to path `resvg-convert in.svg -f svg -o out.svg`
- .. and to other vector based formats "pdf", "eps", "ps".

What is not working:
- `--export-id` is exporting an object in raster images
- Not done in the Qt backend. Not sure if even doable?

What is left to do:
- Fix build
- Add tests
- Taking SVG input from standard input
- Go through other rsvg-convert options
- Get reviews and feedback.