### PR TITLE
raqote-backend: Use copy_surface in apply_to_canvas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "raqote"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "euclid 0.19.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -588,7 +588,7 @@ dependencies = [
  "gdk-pixbuf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "raqote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "raqote 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "resvg-qt 0.7.0",
  "rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "usvg 0.7.0",
@@ -858,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum raqote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "94b137b6291c2ceffb7f6ff62bb3f462d9e2734feeca3e962bb4c957ccc8876d"
+"checksum raqote 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ed2f21df4a18a45dfc4c5d71b18b23618c63db12e3cfc21ad2a3318049ff83d"
 "checksum rctree 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "193d11923532b462b7231e2d7fb785a9c0d580b03c0eccac460a1e9ee0e87fda"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum rgb 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)" = "4f089652ca87f5a82a62935ec6172a534066c7b97be003cc8f702ee9a7a59c92"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ gdk-pixbuf = { version = "0.6", optional = true }
 resvg-qt = { path = "resvg-qt", version = "0.7", optional = true }
 
 # raqote backend
-raqote = { version = "0.5.2", default-features = false, optional = true }
+raqote = { version = "0.5.3", default-features = false, optional = true }
 
 [dependencies.image]
 version = "0.21"

--- a/src/backend_raqote/filter.rs
+++ b/src/backend_raqote/filter.rs
@@ -437,13 +437,12 @@ impl Filter<raqote::DrawTarget> for RaqoteFilter {
         canvas.set_transform(&raqote::Transform::identity());
         canvas.make_transparent();
 
-        let draw_opt = raqote::DrawOptions {
-            blend_mode: raqote::BlendMode::SrcOver,
-            ..raqote::DrawOptions::default()
-        };
-        canvas.draw_image_at(
-            region.x() as f32, region.y() as f32, &input.as_ref().as_image(), &draw_opt,
-        );
+        let image = input.as_ref();
+
+        canvas.copy_surface(image,
+                            raqote::IntRect::new(raqote::IntPoint::new(0, 0),
+                                                 raqote::IntPoint::new(image.width(), image.height())),
+                            raqote::IntPoint::new(region.x(), region.y()));
 
         Ok(())
     }


### PR DESCRIPTION
This reduces rendering time of camera.svg from
17070.79ms to 13718.67ms