### PR TITLE
Update BUILD.adoc

### DIFF
--- a/BUILD.adoc
+++ b/BUILD.adoc
@@ -221,21 +221,6 @@ SKIA_DIR=path SKIA_LIB_DIR=path cargo build --release --features "skia-backend"
 
 == macOS
 
-We assume that you have already built Skia itself.
-
-Install `harfbuzz` using Homebrew via:
-
-```
-brew install harfbuzz
-```
-
-`SKIA_DIR` should point to a Skia directory that contains the Skia `include` directory.
-`SKIA_LIB_DIR` should point to a Skia directory that contains `libskia.dylib`.
-
-```sh
-SKIA_DIR=path SKIA_LIB_DIR=path cargo build --release --features "skia-backend"
-```
-
 === Qt backend
 
 Using https://brew.sh/[homebrew]:
@@ -273,7 +258,20 @@ cargo build --release --features "raqote-backend"
 
 === Skia backend
 
-Not supported.
+We assume that you have already built Skia itself.
+
+Install `harfbuzz` using Homebrew via:
+
+```
+brew install harfbuzz
+```
+
+`SKIA_DIR` should point to a Skia directory that contains the Skia `include` directory.
+`SKIA_LIB_DIR` should point to a Skia directory that contains `libskia.dylib`.
+
+```sh
+SKIA_DIR=path SKIA_LIB_DIR=path cargo build --release --features "skia-backend"
+```
 
 == For maintainers
 


### PR DESCRIPTION
Moved MacOS Skia build instructions under MacOS|Skia backend sub-heading.  It was under the main MacOS heading.
