### PR TITLE
Add meson.build for distro packagers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,28 @@
+project('resvg', 'c', version: '0.9.0')
+
+cargo = find_program('cargo', required: true)
+
+cargo_script = find_program('scripts/build.sh')
+
+lib = 'libresvg.so.0.'+meson.project_version()
+
+target = custom_target('resvg',
+                       build_by_default: true,
+                       install: true,
+                       install_dir: lib,
+                       console: true,
+                       output: 'libresvg.so.0.'+meson.project_version(),
+                       command: [cargo_script, '@SOURCE_ROOT@', '@OUTPUT@', meson.build_root(), get_option('buildtype'), get_option('backends')])
+
+if get_option('backends') == 'both' or get_option('backends') == 'qt'
+    install_headers(['capi/include/resvg.h', 'capi/include/ResvgQt.h'], subdir: 'resvg')
+endif
+
+pkg = import('pkgconfig')
+
+pkg.generate(libraries: '-L${libdir} -lresvg',
+             name: 'resvg',
+             description: 'An SVG rendering library',
+             subdirs: 'resvg')
+
+meson.add_install_script('scripts/link.sh', join_paths(get_option('prefix'), get_option('libdir')), lib)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('backends', type : 'combo', choices : ['both', 'qt', 'cairo'], value : 'both')

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+export source_root="$1"
+export output="$2"
+export meson_build_root="$3"
+export release_profile="$4"
+export featureset="$5"
+
+export CARGO_TARGET_DIR="$meson_build_root"/cargo-target
+export CARGO_HOME="$meson_build_root"/cargo-home
+
+if [ "$featureset" = "both" ]; then
+    features="qt-backend cairo-backend"
+elif [ "$featureset" = "qt" ]; then
+    features="qt-backend"
+else
+    features="cairo-backend"
+fi
+
+if [ "$release_profile" = "debug" ]; then
+    cargo build --manifest-path "$1"/Cargo.toml --features "$features"
+    cargo build --manifest-path "$1"/capi/Cargo.toml --features "$features"
+    cp "$CARGO_TARGET_DIR"/debug/libresvg.so "$2"
+else
+    cargo build --manifest-path "$1"/Cargo.toml --release --features "$features"
+    cargo build --manifest-path "$1"/capi/Cargo.toml --release --features "$features"
+    cp "$CARGO_TARGET_DIR"/debug/libresvg.so "$2"
+fi

--- a/scripts/link.sh
+++ b/scripts/link.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ln -sf "$DESTDIR/$1/$2" "$DESTDIR/$1/libresvg.so.0"
+ln -sf "$DESTDIR/$1/$2" "$DESTDIR/$1/libresvg.so"


### PR DESCRIPTION
A meson.build wraps around Cargo.toml to manage installation of necessary files, allowing distro packagers to have an easier time packaging.

This also generates a pkgconfig file in order for C/C++ projects to be able to depend on resvg without needing to vendor it.