### PR TITLE
Add -h flag to usvg-cli to match usage text

### DIFF
--- a/tools/usvg/src/main.rs
+++ b/tools/usvg/src/main.rs
@@ -83,7 +83,7 @@ struct Args {
 fn collect_args() -> Result<Args, pico_args::Error> {
     let mut input = Arguments::from_env();
     Ok(Args {
-        help:               input.contains("--help"),
+        help:               input.contains(["-h", "--help"]),
         version:            input.contains(["-V", "--version"]),
         stdout:             input.contains("-c"),
         keep_named_groups:  input.contains("--keep-named-groups"),


### PR DESCRIPTION
Hello, and thank you for your work on this crate, it is greatly appreciated!

I was using `usvg` and attempted to use `-h` which was not recognized.  `--help` shows it as a valid option, so this extraordinarily small PR just adds the flag in.