### PR TITLE
Bugfix: fixes dy calculation for textPath

### DIFF
--- a/testing-tools/regression/allow-cairo.txt
+++ b/testing-tools/regression/allow-cairo.txt
@@ -1,1 +1,5 @@
+e-textPath-023.svg
+e-textPath-027.svg
+e-textPath-032.svg
+e-textPath-033.svg
 e-textPath-035.svg

--- a/testing-tools/regression/allow-cairo.txt
+++ b/testing-tools/regression/allow-cairo.txt
@@ -1,2 +1,1 @@
-e-image-038.svg
-e-image-039.svg
+e-textPath-035.svg

--- a/testing-tools/regression/allow-qt.txt
+++ b/testing-tools/regression/allow-qt.txt
@@ -1,1 +1,5 @@
+e-textPath-023.svg
+e-textPath-027.svg
+e-textPath-032.svg
+e-textPath-033.svg
 e-textPath-035.svg

--- a/testing-tools/regression/allow-qt.txt
+++ b/testing-tools/regression/allow-qt.txt
@@ -1,2 +1,1 @@
-e-image-038.svg
-e-image-039.svg
+e-textPath-035.svg

--- a/testing-tools/regression/allow-raqote.txt
+++ b/testing-tools/regression/allow-raqote.txt
@@ -1,1 +1,5 @@
+e-textPath-023.svg
+e-textPath-027.svg
+e-textPath-032.svg
+e-textPath-033.svg
 e-textPath-035.svg

--- a/testing-tools/regression/allow-raqote.txt
+++ b/testing-tools/regression/allow-raqote.txt
@@ -1,2 +1,1 @@
-e-image-038.svg
-e-image-039.svg
+e-textPath-035.svg

--- a/testing-tools/regression/allow-skia.txt
+++ b/testing-tools/regression/allow-skia.txt
@@ -1,1 +1,5 @@
+e-textPath-023.svg
+e-textPath-027.svg
+e-textPath-032.svg
+e-textPath-033.svg
 e-textPath-035.svg

--- a/testing-tools/regression/allow-skia.txt
+++ b/testing-tools/regression/allow-skia.txt
@@ -1,2 +1,1 @@
-e-image-038.svg
-e-image-039.svg
+e-textPath-035.svg

--- a/usvg/src/convert/text/shaper.rs
+++ b/usvg/src/convert/text/shaper.rs
@@ -556,7 +556,7 @@ fn resolve_clusters_positions_path(
         // Shift only by `dy` since we already applied `dx`
         // during offset along the path calculation.
         if !dy.is_fuzzy_zero() || !baseline_shift.is_fuzzy_zero() {
-            let shift = kurbo::Vec2::from_angle(angle) + kurbo::Vec2::new(0.0, dy - baseline_shift);
+            let shift = kurbo::Vec2::new(0.0, dy - baseline_shift);
             cluster.transform.translate(shift.x, shift.y);
         }
 


### PR DESCRIPTION
There seems to be a subtle error when using `text` `textPath` in combination with the `dy` attribute:

Original (upper `textPath` has `dy` attribute, lower path doesn't):
![Original](https://user-images.githubusercontent.com/5731969/83509176-56cfd980-a4cb-11ea-82ae-6110f2dad64d.png)

With this PR:
![Fixed](https://user-images.githubusercontent.com/5731969/83509182-57687000-a4cb-11ea-9493-2455600b9c7c.png)

Since the position is only off by a distance of 1, the error is only noticeable for small coordinate values.

Svg-file:
[TwoPathsWithDy.zip](https://github.com/RazrFalcon/resvg/files/4716439/TwoPathsWithDy.zip)

I'm a bit unsure on how to run the test suite and haven't done that - sorry! I can dig further into this if required.

```xml
<svg id="svg1" viewBox="0 0 2 2" width="500" height="500" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
	<title>
		Two paths with dy
	</title>
	<path id="pathForText1" d="M 0.20 0.73 C 0.35 1.08 0.85 1.08 1.00 0.73 C 1.15 0.38 1.65 0.38 1.80 0.73" fill="none" stroke="gray" stroke-width="0.03" />
	<path id="pathForText2" d="M 0.20 1.27 C 0.35 1.62 0.85 1.62 1.00 1.27 C 1.15 0.92 1.65 0.92 1.80 1.27" fill="none" stroke="gray" stroke-width="0.03" />
	<text id="text1" font-family="serif" font-size="0.24" stroke="none" dy="0.1">
		<textPath id="textPath1" xlink:href="#pathForText1">
			Some long text
		</textPath>
		<textPath id="textPath2" xlink:href="#pathForText2">
			Some long text
		</textPath>
	</text>
	<!-- image frame -->
	<rect id="frame" x="0.01" y="0.01" width="1.98" height="1.98" fill="none" stroke="black" stroke-width="0.1" />
</svg>
```