### PR TITLE
Bugfix: TextPath ignored transformed paths

### DIFF
--- a/testing-tools/regression/allow-cairo.txt
+++ b/testing-tools/regression/allow-cairo.txt
@@ -1,5 +1,0 @@
-e-textPath-023.svg
-e-textPath-027.svg
-e-textPath-032.svg
-e-textPath-033.svg
-e-textPath-035.svg

--- a/testing-tools/regression/allow-cairo.txt
+++ b/testing-tools/regression/allow-cairo.txt
@@ -1,0 +1,1 @@
+e-textPath-036.svg

--- a/testing-tools/regression/allow-qt.txt
+++ b/testing-tools/regression/allow-qt.txt
@@ -1,5 +1,0 @@
-e-textPath-023.svg
-e-textPath-027.svg
-e-textPath-032.svg
-e-textPath-033.svg
-e-textPath-035.svg

--- a/testing-tools/regression/allow-qt.txt
+++ b/testing-tools/regression/allow-qt.txt
@@ -1,0 +1,1 @@
+e-textPath-036.svg

--- a/testing-tools/regression/allow-raqote.txt
+++ b/testing-tools/regression/allow-raqote.txt
@@ -1,5 +1,0 @@
-e-textPath-023.svg
-e-textPath-027.svg
-e-textPath-032.svg
-e-textPath-033.svg
-e-textPath-035.svg

--- a/testing-tools/regression/allow-raqote.txt
+++ b/testing-tools/regression/allow-raqote.txt
@@ -1,0 +1,1 @@
+e-textPath-036.svg

--- a/testing-tools/regression/allow-skia.txt
+++ b/testing-tools/regression/allow-skia.txt
@@ -1,5 +1,0 @@
-e-textPath-023.svg
-e-textPath-027.svg
-e-textPath-032.svg
-e-textPath-033.svg
-e-textPath-035.svg

--- a/testing-tools/regression/allow-skia.txt
+++ b/testing-tools/regression/allow-skia.txt
@@ -1,0 +1,1 @@
+e-textPath-036.svg

--- a/usvg/src/convert/text/convert.rs
+++ b/usvg/src/convert/text/convert.rs
@@ -5,8 +5,8 @@
 use std::cmp;
 use std::rc::Rc;
 
-use crate::{fontdb, svgtree, tree};
-use crate::{Transform, convert::{prelude::*, style, units}};
+use crate::{fontdb, svgtree, tree, Transform};
+use crate::convert::{prelude::*, style, units};
 use super::TextNode;
 
 
@@ -306,7 +306,16 @@ fn resolve_text_flow(
     }
 
     let path = path_node.attribute::<tree::SharedPathData>(AId::D)?;
-
+    
+    // The reference path's transform needs to be applied
+    let path = if let Some(node_transform) = path_node.attribute::<Transform>(AId::Transform) {
+        let mut path_copy = path.as_ref().clone();
+        path_copy.transform(node_transform);
+        Rc::new(path_copy)
+    } else {
+        path.clone()
+    };
+    
     let start_offset: Length = node.attribute(AId::StartOffset).unwrap_or_default();
     let start_offset = if start_offset.unit == Unit::Percent {
         // 'If a percentage is given, then the `startOffset` represents
@@ -317,13 +326,6 @@ fn resolve_text_flow(
         node.resolve_length(AId::StartOffset, state, 0.0)
     };
 
-    let path = if let Some(node_transform) = path_node.attribute::<Transform>(AId::Transform) {
-        let mut path_copy = path.as_ref().clone();
-        path_copy.transform(node_transform);
-        Rc::new(path_copy)
-    } else {
-        path.clone()
-    };
 
     Some(TextFlow::Path(Rc::new(TextPath {
         start_offset,

--- a/usvg/src/convert/text/shaper.rs
+++ b/usvg/src/convert/text/shaper.rs
@@ -521,8 +521,12 @@ fn resolve_clusters_positions_path(
     let start_offset = chunk_offset + path.start_offset
         + process_anchor(chunk.anchor, clusters_length(clusters));
 
+
+    let mut transformed_path = path.path.as_ref().clone();
+    transformed_path.transform(path.transform);
+
     let normals = collect_normals(
-        chunk, clusters, &path.path, pos_list, char_offset, start_offset,
+        chunk, clusters, &transformed_path, pos_list, char_offset, start_offset,
     );
     for (cluster, normal) in clusters.iter_mut().zip(normals) {
         let (x, y, angle) = match normal {

--- a/usvg/src/convert/text/shaper.rs
+++ b/usvg/src/convert/text/shaper.rs
@@ -521,12 +521,8 @@ fn resolve_clusters_positions_path(
     let start_offset = chunk_offset + path.start_offset
         + process_anchor(chunk.anchor, clusters_length(clusters));
 
-
-    let mut transformed_path = path.path.as_ref().clone();
-    transformed_path.transform(path.transform);
-
     let normals = collect_normals(
-        chunk, clusters, &transformed_path, pos_list, char_offset, start_offset,
+        chunk, clusters, &path.path, pos_list, char_offset, start_offset,
     );
     for (cluster, normal) in clusters.iter_mut().zip(normals) {
         let (x, y, angle) = match normal {


### PR DESCRIPTION
Okay, here goes nothing. Transformation is now (somewhat hacky) calculated when the textPath is resolved.