### PR TITLE
Enhance viewsvg.pro with RPATH, debug_and_release

### DIFF
--- a/tools/viewsvg/README.md
+++ b/tools/viewsvg/README.md
@@ -8,6 +8,7 @@ A simple SVG viewer using Qt and *resvg* C-API.
 
 ## Build
 
+To build a release version:
 ```bash
 # build C-API first
 cargo build --release --features "qt-backend" --manifest-path ../../capi/Cargo.toml
@@ -15,7 +16,15 @@ cargo build --release --features "qt-backend" --manifest-path ../../capi/Cargo.t
 qmake
 make
 # run
-LD_LIBRARY_PATH=../../target/release ./viewsvg
+./viewsvg
+```
+
+Or, to build in debug mode:
+```bash
+cargo build --debug --features "qt-backend" --manifest-path ../../capi/Cargo.toml
+qmake
+make debug
+./viewsvg
 ```
 
 See [BUILD.adoc](../../BUILD.adoc) for details.

--- a/tools/viewsvg/viewsvg.pro
+++ b/tools/viewsvg/viewsvg.pro
@@ -16,8 +16,19 @@ HEADERS += \
 FORMS += \
     mainwindow.ui
 
-CONFIG(release, debug|release): LIBS += -L$$PWD/../../target/release/ -lresvg
-else:CONFIG(debug, debug|release): LIBS += -L$$PWD/../../target/debug/ -lresvg
+LIBS += -lresvg
 
-INCLUDEPATH += $$PWD/../../capi/include
-DEPENDPATH += $$PWD/../../capi/include
+BASEDIR = $$absolute_path(../../target)
+
+QMAKE_LFLAGS_RELEASE += -L$$absolute_path(release,$$BASEDIR)
+QMAKE_LFLAGS_DEBUG += -L$$absolute_path(debug,$$BASEDIR)
+
+CONFIG(release, debug|release) {
+	QMAKE_RPATHDIR += $$absolute_path(release,$$BASEDIR)
+}
+else:CONFIG(debug, debug|release) {
+	QMAKE_RPATHDIR += $$absolute_path(debug,$$BASEDIR)
+}
+
+INCLUDEPATH += $$absolute_path(../../capi/include)
+DEPENDPATH += $$absolute_path(../../capi/include)


### PR DESCRIPTION
- Config set up for `debug_and_release` (`release` is default)
  - `make` or `make release` will use release configs
  - `make debug` will build in debug mode
    (`qmake` does not need to be re-run to switch mode)
- `QMAKE_RPATHDIR` is set for both build modes, to avoid requiring `LD_LIBRARY_PATH` at runtime
- Readme updated accordingly