### PR TITLE
Fix viewsvg.pro CONFIG mode

### DIFF
--- a/tools/viewsvg/viewsvg.pro
+++ b/tools/viewsvg/viewsvg.pro
@@ -2,7 +2,7 @@ QT += core gui widgets
 
 TARGET = viewsvg
 TEMPLATE = app
-CONFIG += C++11
+CONFIG += C++11 debug_and_release
 
 SOURCES += \
     main.cpp \


### PR DESCRIPTION
Whoops! I somehow left out a crucial edit, in #296 — without `debug_and_release` in CONFIG, qmake actually does nothing for _either_ mode.