### PR TITLE
Update ttf-parser/fontdb, base64 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ checksum = "75224bec9bfe1a65e2d34132933f2de7fe79900c96a0174307554244ece8150e"
 
 [[package]]
 name = "fontdb"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa64e442fe4adbae6edd55ab3ebe905a858208db2aa12ab204e261890b69fd5"
+checksum = "80c798d52612851a39f84d857a8e63191103bfdf28baf10011720487043b7c15"
 dependencies = [
  "log",
  "memmap2",
@@ -514,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.6.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5d7cd7ab3e47dda6e56542f4bbf3824c15234958c6e1bd6aaa347e93499fdc"
+checksum = "7622061403fd00f0820df288e5a580e87d3ce15a1c4313c59fd1ffb77129903f"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"

--- a/usvg/Cargo.toml
+++ b/usvg/Cargo.toml
@@ -37,10 +37,10 @@ siphasher = "0.2"
 svgtypes = "0.5"
 
 # for text to path
-fontdb = { version = "0.1", optional = true }
+fontdb = { version = "0.2", optional = true }
 rustybuzz = { version = "0.1", optional = true }
 memmap2 = { version = "0.1", optional = true }
-ttf-parser = { version = "0.6", optional = true }
+ttf-parser = { version = "0.8", optional = true }
 unicode-bidi = { version = "0.3", optional = true }
 unicode-script = { version = "0.5", optional = true }
 unicode-vo = { version = "0.1", optional = true }

--- a/usvg/Cargo.toml
+++ b/usvg/Cargo.toml
@@ -21,7 +21,7 @@ name = "usvg"
 required-features = ["text"]
 
 [dependencies]
-base64 = "0.12"
+base64 = "0.13"
 data-url = "0.1"
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"]}
 kurbo = "0.7"

--- a/usvg/src/fontdb_ext.rs
+++ b/usvg/src/fontdb_ext.rs
@@ -17,7 +17,7 @@ impl DatabaseExt for Database {
     #[inline(never)]
     fn load_font(&self, id: ID) -> Option<Font> {
         self.with_face_data(id, |data, face_index| -> Option<Font> {
-            let font = ttf_parser::Font::from_data(data, face_index)?;
+            let font = ttf_parser::Face::from_slice(data, face_index).ok()?;
 
             let units_per_em = NonZeroU16::new(font.units_per_em()?)?;
 
@@ -87,7 +87,7 @@ impl DatabaseExt for Database {
     #[inline(never)]
     fn outline(&self, id: ID, glyph_id: GlyphId) -> Option<tree::PathData> {
         self.with_face_data(id, |data, face_index| -> Option<tree::PathData> {
-            let font = ttf_parser::Font::from_data(&data, face_index)?;
+            let font = ttf_parser::Face::from_slice(&data, face_index).ok()?;
 
             let mut builder = PathBuilder { path: tree::PathData::with_capacity(16) };
             font.outline_glyph(glyph_id, &mut builder)?;
@@ -98,7 +98,7 @@ impl DatabaseExt for Database {
     #[inline(never)]
     fn has_char(&self, id: ID, c: char) -> bool {
         let res = self.with_face_data(id, |font_data, face_index| -> Option<bool> {
-            let font = ttf_parser::Font::from_data(font_data, face_index)?;
+            let font = ttf_parser::Face::from_slice(font_data, face_index).ok()?;
             font.glyph_index(c)?;
             Some(true)
         });


### PR DESCRIPTION
This reduces dependency duplication when using other crates that already use ttf-parser 0.8.