### PR TITLE
Add features to build for web-sys. #229

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ rayon = "1.3"
 
 [features]
 default = ["text"]
-text = ["usvg/text"] # enables SVG Text support
+text = ["usvg/system-fonts", "usvg/text"] # enables SVG Text support

--- a/usvg/Cargo.toml
+++ b/usvg/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "RazrFalcon/resvg" }
 
 [[bin]]
 name = "usvg"
-required-features = ["text"]
+required-features = ["system-fonts", "text"]
 
 [dependencies]
 base64 = "0.13"
@@ -37,7 +37,7 @@ siphasher = "0.2"
 svgtypes = "0.5"
 
 # for text to path
-fontdb = { version = "0.4", optional = true }
+fontdb = { version = "0.4", optional = true, default-features = false }
 rustybuzz = { version = "0.3", optional = true }
 memmap2 = { version = "0.1", optional = true }
 ttf-parser = { version = "0.9", optional = true }
@@ -46,13 +46,16 @@ unicode-script = { version = "0.5", optional = true }
 unicode-vo = { version = "0.1", optional = true }
 
 [features]
-default = ["text"]
+default = ["system-fonts", "text"]
 text = [
     "fontdb",
-    "memmap2",
     "rustybuzz",
     "ttf-parser",
     "unicode-bidi",
     "unicode-script",
     "unicode-vo",
+]
+system-fonts = [
+    "fontdb/fs",
+    "memmap2",
 ]

--- a/usvg/src/lib.rs
+++ b/usvg/src/lib.rs
@@ -244,7 +244,7 @@ pub trait SystemFontDB {
     fn load_system_fonts(&mut self);
 }
 
-#[cfg(feature = "text")]
+#[cfg(feature = "system-fonts")]
 impl SystemFontDB for fontdb::Database {
     #[inline]
     fn load_system_fonts(&mut self) {


### PR DESCRIPTION
This is the other half of https://github.com/RazrFalcon/resvg/issues/229. A user can depend on usvg with `default-features = false, features = ["text", "text_web-sys"]` to enable this new behavior.

After the PR in fontdb is merged, I'll change this PR to pin to the latest git commit on the upstream fontdb repo, and regenerate Cargo.lock for usvg.

I tested both of these PRs by pinning A/B Street web to my local copies.