### PR TITLE
Allow usvg to process files with no viewBox and relative root dimensions.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -377,11 +377,15 @@ fn parse_args() -> Result<Args, String> {
     let keep_named_groups = args.query_all || export_id.is_some();
 
     let mut fit_to = usvg::FitTo::Original;
+    let mut default_size = usvg::Size::new(100.0, 100.0).unwrap();
     if let (Some(w), Some(h)) = (args.width, args.height) {
+        default_size = usvg::Size::new(w as f64, h as f64).unwrap();
         fit_to = usvg::FitTo::Size(w, h);
     } else if let Some(w) = args.width {
+        default_size = usvg::Size::new(w as f64, 100.0).unwrap();
         fit_to = usvg::FitTo::Width(w);
     } else if let Some(h) = args.height {
+        default_size = usvg::Size::new(100.0, h as f64).unwrap();
         fit_to = usvg::FitTo::Height(h);
     } else if let Some(z) = args.zoom {
         fit_to = usvg::FitTo::Zoom(z);
@@ -405,6 +409,7 @@ fn parse_args() -> Result<Args, String> {
         text_rendering: args.text_rendering,
         image_rendering: args.image_rendering,
         keep_named_groups,
+        default_size,
         fontdb,
     };
 

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -113,6 +113,8 @@ struct Args {
     font_dirs: Vec<PathBuf>,
     skip_system_fonts: bool,
     list_fonts: bool,
+    default_width: u32,
+    default_height: u32,
 
     keep_named_groups: bool,
     id_prefix: Option<String>,
@@ -158,6 +160,8 @@ fn collect_args() -> Result<Args, pico_args::Error> {
         font_dirs:          input.values_from_str("--use-fonts-dir")?,
         skip_system_fonts:  input.contains("--skip-system-fonts"),
         list_fonts:         input.contains("--list-fonts"),
+        default_width:      input.opt_value_from_fn("--default-width", parse_length)?.unwrap_or(100),
+        default_height:     input.opt_value_from_fn("--default-height", parse_length)?.unwrap_or(100),
 
         keep_named_groups:  input.contains("--keep-named-groups"),
         id_prefix:          input.opt_value_from_str("--id-prefix")?,
@@ -219,6 +223,16 @@ fn parse_indent(s: &str) -> Result<xmlwriter::Indent, String> {
     };
 
     Ok(indent)
+}
+
+fn parse_length(s: &str) -> Result<u32, String> {
+    let n: u32 = s.parse().map_err(|_| "invalid length")?;
+
+    if n > 0 {
+        Ok(n)
+    } else {
+        Err("LENGTH cannot be zero".to_string())
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -336,6 +350,7 @@ fn process(args: Args) -> Result<(), String> {
         text_rendering: args.text_rendering,
         image_rendering: args.image_rendering,
         keep_named_groups: args.keep_named_groups,
+        default_size: usvg::Size::new(args.default_width as f64, args.default_height as f64).unwrap(),
         fontdb,
     };
 

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -78,6 +78,15 @@ OPTIONS:
                                 Otherwise, text elements will not be processes
   --list-fonts                  Lists successfully loaded font faces.
                                 Useful for debugging
+  --default-width LENGTH        Sets the default width of the SVG viewport. Like
+                                the '--default-height' option, this option
+                                controlls what size relative units in the document
+                                will use as a base if there is no viewBox and
+                                document width or height are relative.
+                                [values: 1..2^32] [default: 100]
+  --default-height LENGTH       Sets the default height of the SVG viewport.
+                                Refer to the explanation of the '--default-width'
+                                option. [values: 1..2^32] [default: 100]
 
   --keep-named-groups           Disables removing of groups with non-empty ID
   --id-prefix                   Adds a prefix to each ID attribute

--- a/usvg/src/options.rs
+++ b/usvg/src/options.rs
@@ -121,6 +121,12 @@ pub struct Options {
     /// Default: false
     pub keep_named_groups: bool,
 
+    /// Default viewport size to assume if there is no `viewBox` attribute and
+    /// the `width` or `height` attributes are relative.
+    ///
+    /// Default: `(100, 100)`
+    pub default_size: Size,
+
     /// When empty, `text` elements will be skipped.
     ///
     /// Default: empty
@@ -141,6 +147,7 @@ impl Default for Options {
             text_rendering: TextRendering::default(),
             image_rendering: ImageRendering::default(),
             keep_named_groups: false,
+            default_size: Size::new(100.0, 100.0).unwrap(),
             #[cfg(feature = "text")]
             fontdb: fontdb::Database::new(),
         }
@@ -161,6 +168,7 @@ impl Options {
             text_rendering: self.text_rendering,
             image_rendering: self.image_rendering,
             keep_named_groups: self.keep_named_groups,
+            default_size: self.default_size,
             #[cfg(feature = "text")]
             fontdb: &self.fontdb,
         }
@@ -183,6 +191,7 @@ pub struct OptionsRef<'a> {
     pub text_rendering: TextRendering,
     pub image_rendering: ImageRendering,
     pub keep_named_groups: bool,
+    pub default_size: Size,
     #[cfg(feature = "text")]
     pub fontdb: &'a fontdb::Database,
 }

--- a/usvg/src/tree/mod.rs
+++ b/usvg/src/tree/mod.rs
@@ -7,7 +7,7 @@
 use std::cell::Ref;
 
 pub use self::{nodes::*, attributes::*, pathdata::*};
-use crate::{svgtree, Rect, Error, OptionsRef, XmlOptions};
+use crate::{svgtree, Size, Rect, Error, OptionsRef, XmlOptions};
 
 mod attributes;
 mod export;
@@ -157,6 +157,22 @@ impl Tree {
     #[inline]
     pub fn to_string(&self, opt: &XmlOptions) -> String {
         export::convert(self, opt)
+    }
+
+    /// Set a view box for the tree.
+    pub(crate) fn set_view_box(&mut self, rect: Rect) {
+        if let NodeKind::Svg(svg) = &mut *self.root.borrow_mut() {
+            svg.view_box.rect = rect;
+        }
+    }
+
+    /// Set dimensions for the tree.
+    pub(crate) fn set_dimensions(&mut self, width: f64, height: f64) {
+        if let NodeKind::Svg(svg) = &mut *self.root.borrow_mut() {
+            if let Some(size) = Size::new(width, height) {
+                svg.size = size;
+            }
+        }
     }
 }
 

--- a/usvg/tests/test.rs
+++ b/usvg/tests/test.rs
@@ -124,6 +124,19 @@ test_size!(size_detection_3,
     usvg::Size::new(5.0, 20.0).unwrap()
 );
 
+test_size!(size_detection_4,
+    "<svg xmlns='http://www.w3.org/2000/svg'><circle fill='#F4900C' cx='18' cy='18' r='18'/></svg>",
+    usvg::Size::new(36.0, 36.0).unwrap()
+);
+
+#[test]
+fn viewbox_detection() {
+    use usvg::FuzzyEq;
+    let opt = usvg::Options::default();
+    let tree = usvg::Tree::from_str("<svg xmlns='http://www.w3.org/2000/svg'><circle fill='#F4900C' cx='18' cy='18' r='18'/></svg>", &opt.to_ref()).unwrap();
+    assert!(tree.svg_node().view_box.rect.fuzzy_eq(&usvg::Rect::new(0.0, 0.0, 36.0, 36.0).unwrap()));
+}
+
 macro_rules! test_size_err {
     ($name:ident, $input:expr) => {
         #[test]
@@ -134,8 +147,5 @@ macro_rules! test_size_err {
     };
 }
 
-test_size_err!(size_detection_err_1,
-    "<svg width='50%' height='100%' xmlns='http://www.w3.org/2000/svg'>");
-
-test_size_err!(size_detection_err_2,
+test_size_err!(size_detection_err,
     "<svg width='0' height='0' viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'>");


### PR DESCRIPTION
As discussed in #40 today, here is a PR that allows files without a `viewBox` and with relative `width`s or `height`s to be converted into the Micro SVG format.

For this, the commit introduces the new `ViewportIntent` enumeration with the variants `Unknown` (default) and `PresetSize`.

- `Unknown` can be used for documents without relative units to fit a `viewBox` as tight around the path bounding boxes as possible
- `PresetSize` can also process relative units, but has to know the viewport size the SVG will be rendered into.