### PR TITLE
cargo: Remove unneeded required-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ members = ["c-api", "svgfilters", "usvg"]
 
 [[bin]]
 name = "resvg"
-required-features = ["filter", "text", "system-fonts", "memmap-fonts"]
 
 [dependencies]
 jpeg-decoder = { version = "0.1", default-features = false }

--- a/usvg/Cargo.toml
+++ b/usvg/Cargo.toml
@@ -15,7 +15,7 @@ workspace = ".."
 
 [[bin]]
 name = "usvg"
-required-features = ["filter", "text", "system-fonts", "memmap-fonts", "export"]
+required-features = ["export"]
 
 [dependencies]
 base64 = "0.13" # for embedded images


### PR DESCRIPTION
Having all default features listed as `required-features` makes it impossible to build the binaries with them off. This PR removes all `required-features` except for usvg's `export` feature from the binaries, as the binaries work fine without them. This is necessary for wasm builds, as wasm does not support the memmap-fonts feature.

Ideally I think this should be done by having these features default to "on", with an override to turn them off--but AFAICT cargo does not support such "negative" features.