### PR TITLE
Exclude test data from the crates.io tarball

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 edition = "2018"
 description = "An SVG rendering library."
 repository = "https://github.com/RazrFalcon/resvg"
+exclude = ["tests"]
 
 [workspace]
 members = ["c-api", "svgfilters", "usvg"]


### PR DESCRIPTION
Reduces the crate size on crates.io from 7Mb to less than 100Kb.

This matters to people on slow and flaky Internet connections, e.g. those living in China.