### PR TITLE
Added usvg_converter binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,12 @@ The main exception is fonts memory mapping.
 
 [rustybuzz]: https://github.com/RazrFalcon/rustybuzz
 [tiny-skia]: https://github.com/RazrFalcon/tiny-skia
+
+## Converting svg to usvg
+
+If you want to use usvg in some other language, create the binary and use it
+to preprocess your graphics.
+
+```
+cargo run --all-features --bin usvg_converter
+```

--- a/src/bin/usvg_converter.rs
+++ b/src/bin/usvg_converter.rs
@@ -1,0 +1,17 @@
+use usvg;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        println!("Usage:\n\tusvg_converter <in-svg> <out-svg>");
+        return;
+    }
+    let mut opt = usvg::Options::default();
+    // Get file's absolute directory.
+    opt.resources_dir = std::fs::canonicalize(&args[1]).ok().and_then(|p| p.parent().map(|p| p.to_path_buf()));
+    opt.fontdb.load_system_fonts();
+
+    let svg_data = std::fs::read(&args[1]).unwrap();
+    let rtree = usvg::Tree::from_data(&svg_data, &opt.to_ref()).unwrap();
+    std::fs::write(&args[2], rtree.to_string(&usvg::XmlOptions::default())).unwrap();
+}


### PR DESCRIPTION
Hello!

Thanks a lot for your project. I haven't found anything like it! I am working on a project that uses vector graphics heavily. The project uses a mix of javascript and python. My code failed for certain graphics (such as those which used mixed coordinates or had metadata). I needed an SVG simplifier such as usvg. I couldn't find an equivalent in python/javascript that worked. Even inkscape's plain svg option wasn't satisfactory. 

The only thing that worked eventually was your library. While you provide a dump svg option, it needs some digging, especially for people unfamiliar with Rust (such as myself). As a consequence I think my tiny contribution will be useful to others. 

Thanks for all your wonderful work!!