### PR TITLE
fix spurious warning when using --export-id

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -361,7 +361,7 @@ fn parse_args() -> Result<Args, String> {
         println!("Warning: --export-area-page has no effect without --export-id.");
     }
 
-    if !args.export_area_drawing && args.export_id.is_some() {
+    if args.export_area_drawing && args.export_id.is_some() {
         println!("Warning: --export-area-drawing has no effect when --export-id is set.");
     }
 


### PR DESCRIPTION
Warn about `--export-area-drawing` when it's actually used in combination with `--export-id`, not the other way around.