### PR TITLE
Path bbox calucalation should scale stroke width

### DIFF
--- a/usvg/src/pathdata.rs
+++ b/usvg/src/pathdata.rs
@@ -439,7 +439,11 @@ fn calc_bbox_with_transform(
     // TODO: find a better way
     // It's an approximation, but it's better than nothing.
     if let Some(stroke) = stroke {
-        let w = stroke.width.value() / 2.0;
+        let w = stroke.width.value() / if ts.is_default() {
+            2.0
+        } else {
+            2.0 / (ts.a * ts.d - ts.b * ts.c).abs().sqrt()
+        };
         minx -= w;
         miny -= w;
         maxx += w;


### PR DESCRIPTION
Consider a path like

```
<path id="1" fill="none" stroke="#ffffff" stroke-width="4" transform="matrix(0.1 0 0 0.1 0 0)" d="M 0 0 L 0 20 L 20 20 L 20 0 Z"/>
```

A correct bbox for such a path would be something like -2 -2 24 24
scaled down to -0.2 -0.2 2.4 2.4

However, PathData::calc_bbox_with_transform uses original stroke width
added to a transformed path bbox and produces a wrong result of -2 -2 6 6

Scaling stroke width by \sqrt{|a*d - b*c|} helps.