### PR TITLE
fix rust/44095 (f64::clamp) todos

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -103,7 +103,6 @@ fn image_to_mask(data: &mut [rgb::RGBA8]) {
     }
 }
 
-// TODO: https://github.com/rust-lang/rust/issues/44095
 /// Bounds `f64` number.
 #[inline]
 fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
@@ -111,11 +110,5 @@ fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
     debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
 
-    if val > max {
-        max
-    } else if val < min {
-        min
-    } else {
-        val
-    }
+    val.clamp(min, max)
 }

--- a/svgfilters/src/lib.rs
+++ b/svgfilters/src/lib.rs
@@ -251,21 +251,13 @@ pub fn from_linear_rgb(data: &mut [RGBA8]) {
     }
 }
 
-
-// TODO: https://github.com/rust-lang/rust/issues/44095
 #[inline]
 fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
     debug_assert!(min.is_finite());
     debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
 
-    if val > max {
-        max
-    } else if val < min {
-        min
-    } else {
-        val
-    }
+    val.clamp(min, max)
 }
 
 

--- a/usvg/src/utils.rs
+++ b/usvg/src/utils.rs
@@ -6,7 +6,6 @@
 
 use crate::{Align, AspectRatio, Rect, ScreenSize, Size, Transform, ViewBox};
 
-// TODO: https://github.com/rust-lang/rust/issues/44095
 /// Bounds `f64` number.
 #[inline]
 pub(crate) fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
@@ -14,13 +13,7 @@ pub(crate) fn f64_bound(min: f64, val: f64, max: f64) -> f64 {
     debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
 
-    if val > max {
-        max
-    } else if val < min {
-        min
-    } else {
-        val
-    }
+    val.clamp(min, max)
 }
 
 /// Converts `viewBox` to `Transform`.


### PR DESCRIPTION
`A pull request must contain a meaningful improvement to the project.`

This PR only fixes TODO's for the [f64::clamp rfc](https://github.com/rust-lang/rust/issues/44095).
`f64::clamp`is in rust since 1.50.0 -> [doc.rust-lang.org](https://doc.rust-lang.org/std/primitive.f64.html#method.clamp)
