### PR TITLE
Bump tiny-skia to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
-version = "0.6.5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3e1db967020dd509b49cecc024025beba2b1b6cf204618610ba266269d6b9"
+checksum = "642680569bb895b16e4b9d181c60be1ed136fa0c9c7f11d004daf053ba89bf82"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -349,6 +349,17 @@ dependencies = [
  "cfg-if",
  "png",
  "safe_arch",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c114d32f0c2ee43d585367cb013dfaba967ab9f62b90d9af0d696e955e70fa6c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ png = "0.17"
 rgb = "0.8"
 svgfilters = { path = "svgfilters", version = "0.4", optional = true }
 svgtypes = "0.8"
-tiny-skia = "0.6"
+tiny-skia = "0.7"
 usvg = { path = "usvg", version = "0.23.0", default-features = false }
 
 [dev-dependencies]

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "staticlib"]
 log = "0.4"
 resvg = { path = "../", default-features = false }
 usvg = { path = "../usvg", default-features = false }
-tiny-skia = "0.6.1"
+tiny-skia = "0.7.0"
 
 [features]
 # we do not provide the dump-svg/export feature here, because it's not available to C API anyway


### PR DESCRIPTION
You mention that dependency update PRs will not be accepted, so feel free to just close this and do it yourself. However considering that `resvg` doesn't re-export the `tiny-skia` dependency while relying on its types in its public API, I think it would be a bad idea to keep the versions out of sync.
