### PR TITLE
Improve `trim_transparency` and PNG rasterization

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -117,25 +117,15 @@ fn image_to_pixmap(image: &Image, pixmap: &mut [u8]) {
         }
         ImageData::RGBA(data) => {
             for p in data.as_rgba() {
-                pixmap[i + 0] = p.r;
-                pixmap[i + 1] = p.g;
-                pixmap[i + 2] = p.b;
+                let a = p.a as f64 / 255.0;
+                pixmap[i + 0] = (p.r as f64 * a + 0.5) as u8;
+                pixmap[i + 1] = (p.g as f64 * a + 0.5) as u8;
+                pixmap[i + 2] = (p.b as f64 * a + 0.5) as u8;
                 pixmap[i + 3] = p.a;
 
                 i += tiny_skia::BYTES_PER_PIXEL;
             }
-
-            multiply_alpha(pixmap.as_rgba_mut());
         }
-    }
-}
-
-fn multiply_alpha(data: &mut [rgb::RGBA8]) {
-    for p in data {
-        let a = p.a as f64 / 255.0;
-        p.b = (p.b as f64 * a + 0.5) as u8;
-        p.g = (p.g as f64 * a + 0.5) as u8;
-        p.r = (p.r as f64 * a + 0.5) as u8;
     }
 }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -285,19 +285,19 @@ pub fn trim_transparency(pixmap: tiny_skia::Pixmap) -> Option<(i32, i32, tiny_sk
     let mut max_y = 0;
 
     let first_non_zero = {
-        let max_safe_index = pixels.len() >> 4;
+        let max_safe_index = pixels.len() / 8;
 
-        // Find first non-zero byte by looking at 16 bytes a time. If not found
+        // Find first non-zero byte by looking at 8 bytes a time. If not found
         // checking the remaining bytes. This is a lot faster than checking one
         // byte a time.
         (0..max_safe_index)
             .position(|i| {
-                let idx = i << 4;
-                u128::from_ne_bytes((&pixels[idx..(idx + 16)]).try_into().unwrap()) != 0
+                let idx = i * 8;
+                u64::from_ne_bytes((&pixels[idx..(idx + 8)]).try_into().unwrap()) != 0
             })
             .map_or_else(
-                || ((max_safe_index << 4)..pixels.len()).position(|i| pixels[i] != 0),
-                |i| Some(i << 4)
+                || ((max_safe_index * 8)..pixels.len()).position(|i| pixels[i] != 0),
+                |i| Some(i * 8)
             )
     };
 


### PR DESCRIPTION
For PNG rasterization, one quick optimization is to do `multiply_alpha` in the same loop assigning each pixel. When the PNG dimension is large the time here is not ignorable.

For `trim_transparency`, with the current solution we always loop over all pixels to find the boundary, so doing it n times will result in a time complexity of `O(n*WH)`.

This PR changes it to find the first non-transparent pixel starting from each edge. For example we loop over the (1) area until reaching a pixel. And then do the same for (2) (3) (4):

![image](https://user-images.githubusercontent.com/3676859/183252404-23832d92-8c73-4200-9d64-d3316b2a2851.png)

Still, no pixel is scanned twice but we are now skipping all the pixels inside the white area. In the worse case (transparent canvas) this algorithm has the same performance as our current one. But in average case this is a lot faster as the complexity becomes `O(n*(WH-s))` where s is the average non-transparent area size.

Since initially we always scan the pixels in the original data storage order, another optimization is to skip all-zero bytes quickly. That's because a transparent pixel is likely to have rgba(0, 0, 0, 0). Here I'm using `u128::from_ne_bytes((&pixels[idx..(idx + 16)]).try_into().unwrap())` to read 16 bytes which is 4 pixels at a time.

I tested the SVG in #371 (2636×4235), and it shows a pretty big improvement:

**Current master branch**

```
FontDB init: 61.98ms
Reading: 0.70ms
Parsing: 38.02ms
Rendering: 18958.88ms
Saving: 222.37ms
./target/release/resvg --perf test.svg test.png  17.42s user 1.81s system 95% cpu 20.207 total
```

**This PR**

```
FontDB init: 61.36ms
Reading: 0.59ms
Parsing: 33.39ms
Rendering: 8535.01ms
Saving: 232.73ms
./target/release/resvg --perf test.svg test.png  7.50s user 1.31s system 99% cpu 8.880 total
```

Which is 2.22x faster in _Rendering_ phase.