### PR TITLE
Cargo.toml: Specify `rust-version` (currently 1.56)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Yevhenii Reizner <razrfalcon@gmail.com>"]
 keywords = ["svg", "render", "raster", "skia"]
 license = "MPL-2.0"
 edition = "2018"
+rust-version = "1.56"
 description = "An SVG rendering library."
 repository = "https://github.com/RazrFalcon/resvg"
 exclude = ["tests"]


### PR DESCRIPTION
Specify the `rust-version` field in Cargo.toml, so that the minimum supported Rust version is enforced. The prevents installation on older Rust versions, and particularly useful when updating the minimum Rust version in the future (in which case older versions will keep working with older Rust versions).

See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
