### PR TITLE
usvg: add xml option to specify decimal places limit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ OPTIONS:
   -h, --height LENGTH           Sets the height in pixels
   -z, --zoom FACTOR             Zooms the image by a factor
       --dpi DPI                 Sets the resolution
-                                [default: 96] [possible values: 10..4000]
+                                [default: 96] [possible values: 10..4000 (inclusive)]
   --background COLOR            Sets the background color
                                 Examples: red, #fff, #fff000
 
@@ -191,7 +191,7 @@ OPTIONS:
                                 [default: Times New Roman]
   --font-size SIZE              Sets the default font size that will be
                                 used when no 'font-size' is present
-                                [default: 12] [possible values: 1..192]
+                                [default: 12] [possible values: 1..192 (inclusive)]
   --serif-family FAMILY         Sets the 'serif' font family
                                 [default: Times New Roman]
   --sans-serif-family FAMILY    Sets the 'sans-serif' font family

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -92,6 +92,8 @@ OPTIONS:
                                 option. [values: 1..2^32] [default: 100]
 
   --id-prefix                   Adds a prefix to each ID attribute
+  --num-n-decimal-places NUM    limits the decimal places when writing numbers
+                                [values: 0..2^8] [default: 8]
   --indent INDENT               Sets the XML nodes indent
                                 [values: none, 0, 1, 2, 3, 4, tabs] [default: 4]
   --attrs-indent INDENT         Sets the XML attributes indent
@@ -128,6 +130,7 @@ struct Args {
     default_height: u32,
 
     id_prefix: Option<String>,
+    num_n_decimal_places: Option<u8>,
     indent: xmlwriter::Indent,
     attrs_indent: xmlwriter::Indent,
 
@@ -189,6 +192,7 @@ fn collect_args() -> Result<Args, pico_args::Error> {
             .unwrap_or(100),
 
         id_prefix: input.opt_value_from_str("--id-prefix")?,
+        num_n_decimal_places: input.opt_value_from_str("--num-n-decimal-places")?,
         indent: input
             .opt_value_from_fn("--indent", parse_indent)?
             .unwrap_or(xmlwriter::Indent::Spaces(4)),
@@ -407,6 +411,7 @@ fn process(args: Args) -> Result<(), String> {
 
     let xml_opt = usvg::XmlOptions {
         id_prefix: args.id_prefix,
+        num_n_decimal_places: args.num_n_decimal_places.unwrap_or(8),
         writer_opts: xmlwriter::Options {
             use_single_quote: false,
             indent: args.indent,

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -22,88 +22,91 @@ USAGE:
   usvg [OPTIONS] - -c                # from stdin to stdout
 
 OPTIONS:
-  -h, --help                    Prints help information
-  -V, --version                 Prints version information
-  -c                            Prints the output SVG to the stdout
+  -h, --help                        Prints help information
+  -V, --version                     Prints version information
+  -c                                Prints the output SVG to the stdout
 
-  --dpi DPI                     Sets the resolution
-                                [default: 96] [possible values: 10..4000]
-  --languages LANG              Sets a comma-separated list of languages that
-                                will be used during the 'systemLanguage'
-                                attribute resolving
-                                Examples: 'en-US', 'en-US, ru-RU', 'en, ru'
-                                [default: en]
-  --shape-rendering HINT        Selects the default shape rendering method
-                                [default: geometricPrecision]
-                                [possible values: optimizeSpeed, crispEdges,
-                                geometricPrecision]
-  --text-rendering HINT         Selects the default text rendering method
-                                [default: optimizeLegibility]
-                                [possible values: optimizeSpeed, optimizeLegibility,
-                                geometricPrecision]
-  --image-rendering HINT        Selects the default image rendering method
-                                [default: optimizeQuality]
-                                [possible values: optimizeQuality, optimizeSpeed]
-  --resources-dir DIR           Sets a directory that will be used during
-                                relative paths resolving.
-                                Expected to be the same as the directory that
-                                contains the SVG file, but can be set to any.
-                                [default: input file directory
-                                or none when reading from stdin]
+  --dpi DPI                         Sets the resolution
+                                    [default: 96] [possible values: 10..4000]
+  --languages LANG                  Sets a comma-separated list of languages that
+                                    will be used during the 'systemLanguage'
+                                    attribute resolving
+                                    Examples: 'en-US', 'en-US, ru-RU', 'en, ru'
+                                    [default: en]
+  --shape-rendering HINT            Selects the default shape rendering method
+                                    [default: geometricPrecision]
+                                    [possible values: optimizeSpeed, crispEdges,
+                                    geometricPrecision]
+  --text-rendering HINT             Selects the default text rendering method
+                                    [default: optimizeLegibility]
+                                    [possible values: optimizeSpeed, optimizeLegibility,
+                                    geometricPrecision]
+  --image-rendering HINT            Selects the default image rendering method
+                                    [default: optimizeQuality]
+                                    [possible values: optimizeQuality, optimizeSpeed]
+  --resources-dir DIR               Sets a directory that will be used during
+                                    relative paths resolving.
+                                    Expected to be the same as the directory that
+                                    contains the SVG file, but can be set to any.
+                                    [default: input file directory
+                                    or none when reading from stdin]
 
-  --font-family FAMILY          Sets the default font family that will be
-                                used when no 'font-family' is present
-                                [default: Times New Roman]
-  --font-size SIZE              Sets the default font size that will be
-                                used when no 'font-size' is present
-                                [default: 12] [possible values: 1..192]
-  --serif-family FAMILY         Sets the 'serif' font family.
-                                Will be used when no 'font-family' is present
-                                [default: Times New Roman]
-  --sans-serif-family FAMILY    Sets the 'sans-serif' font family
-                                [default: Arial]
-  --cursive-family FAMILY       Sets the 'cursive' font family
-                                [default: Comic Sans MS]
-  --fantasy-family FAMILY       Sets the 'fantasy' font family
-                                [default: Impact]
-  --monospace-family FAMILY     Sets the 'monospace' font family
-                                [default: Courier New]
-  --use-font-file PATH          Load a specified font file into the fonts database.
-                                Will be used during text to path conversion.
-                                This option can be set multiple times
-  --use-fonts-dir PATH          Loads all fonts from the specified directory
-                                into the fonts database.
-                                Will be used during text to path conversion.
-                                This option can be set multiple times
-  --skip-system-fonts           Disables system fonts loading.
-                                You should add some fonts manually using
-                                --use-font-file and/or --use-fonts-dir
-                                Otherwise, text elements will not be processes
-  --list-fonts                  Lists successfully loaded font faces.
-                                Useful for debugging
-  --default-width LENGTH        Sets the default width of the SVG viewport. Like
-                                the '--default-height' option, this option
-                                controls what size relative units in the document
-                                will use as a base if there is no viewBox and
-                                document width or height are relative.
-                                [values: 1..2^32] [default: 100]
-  --default-height LENGTH       Sets the default height of the SVG viewport.
-                                Refer to the explanation of the '--default-width'
-                                option. [values: 1..2^32] [default: 100]
+  --font-family FAMILY              Sets the default font family that will be
+                                    used when no 'font-family' is present
+                                    [default: Times New Roman]
+  --font-size SIZE                  Sets the default font size that will be
+                                    used when no 'font-size' is present
+                                    [default: 12] [possible values: 1..192]
+  --serif-family FAMILY             Sets the 'serif' font family.
+                                    Will be used when no 'font-family' is present
+                                    [default: Times New Roman]
+  --sans-serif-family FAMILY        Sets the 'sans-serif' font family
+                                    [default: Arial]
+  --cursive-family FAMILY           Sets the 'cursive' font family
+                                    [default: Comic Sans MS]
+  --fantasy-family FAMILY           Sets the 'fantasy' font family
+                                    [default: Impact]
+  --monospace-family FAMILY         Sets the 'monospace' font family
+                                    [default: Courier New]
+  --use-font-file PATH              Load a specified font file into the fonts database.
+                                    Will be used during text to path conversion.
+                                    This option can be set multiple times
+  --use-fonts-dir PATH              Loads all fonts from the specified directory
+                                    into the fonts database.
+                                    Will be used during text to path conversion.
+                                    This option can be set multiple times
+  --skip-system-fonts               Disables system fonts loading.
+                                    You should add some fonts manually using
+                                    --use-font-file and/or --use-fonts-dir
+                                    Otherwise, text elements will not be processes
+  --list-fonts                      Lists successfully loaded font faces.
+                                    Useful for debugging
+  --default-width LENGTH            Sets the default width of the SVG viewport. Like
+                                    the '--default-height' option, this option
+                                    controls what size relative units in the document
+                                    will use as a base if there is no viewBox and
+                                    document width or height are relative.
+                                    [values: 1..2^32] [default: 100]
+  --default-height LENGTH           Sets the default height of the SVG viewport.
+                                    Refer to the explanation of the '--default-width'
+                                    option. [values: 1..2^32] [default: 100]
 
-  --id-prefix                   Adds a prefix to each ID attribute
-  --num-n-decimal-places NUM    limits the decimal places when writing numbers
-                                [values: 0..2^8] [default: 8]
-  --indent INDENT               Sets the XML nodes indent
-                                [values: none, 0, 1, 2, 3, 4, tabs] [default: 4]
-  --attrs-indent INDENT         Sets the XML attributes indent
-                                [values: none, 0, 1, 2, 3, 4, tabs] [default: none]
-
-  --quiet                       Disables warnings
+  --id-prefix                       Adds a prefix to each ID attribute
+  --indent INDENT                   Sets the XML nodes indent
+                                    [values: none, 0, 1, 2, 3, 4, tabs] [default: 4]
+  --attrs-indent INDENT             Sets the XML attributes indent
+                                    [values: none, 0, 1, 2, 3, 4, tabs] [default: none]
+  --coordinates-precision NUM       Set the coordinates numeric precision.
+                                    Smaller precision can lead to a malformed output in some cases
+                                    [values: 2..8] [default: 8]
+  --transforms-precision NUM        Set the transform values numeric precision.
+                                    Smaller precision can lead to a malformed output in some cases
+                                    [values: 2..8] [default: 8]
+  --quiet                           Disables warnings
 
 ARGS:
-  <in-svg>                      Input file
-  <out-svg>                     Output file
+  <in-svg>                          Input file
+  <out-svg>                         Output file
 ";
 
 #[derive(Debug)]
@@ -130,9 +133,10 @@ struct Args {
     default_height: u32,
 
     id_prefix: Option<String>,
-    num_n_decimal_places: Option<u8>,
     indent: xmlwriter::Indent,
     attrs_indent: xmlwriter::Indent,
+    coordinates_precision: Option<u8>,
+    transforms_precision: Option<u8>,
 
     quiet: bool,
 
@@ -192,13 +196,14 @@ fn collect_args() -> Result<Args, pico_args::Error> {
             .unwrap_or(100),
 
         id_prefix: input.opt_value_from_str("--id-prefix")?,
-        num_n_decimal_places: input.opt_value_from_str("--num-n-decimal-places")?,
         indent: input
             .opt_value_from_fn("--indent", parse_indent)?
             .unwrap_or(xmlwriter::Indent::Spaces(4)),
         attrs_indent: input
             .opt_value_from_fn("--attrs-indent", parse_indent)?
             .unwrap_or(xmlwriter::Indent::None),
+        coordinates_precision: input.opt_value_from_fn("--coordinates-precision", parse_precision)?,
+        transforms_precision: input.opt_value_from_fn("--transforms-precision", parse_precision)?,
 
         quiet: input.contains("--quiet"),
 
@@ -262,6 +267,16 @@ fn parse_length(s: &str) -> Result<u32, String> {
         Ok(n)
     } else {
         Err("LENGTH cannot be zero".to_string())
+    }
+}
+
+fn parse_precision(s: &str) -> Result<u8, String> {
+    let n: u8 = s.parse().map_err(|_| "invalid length")?;
+
+    if n <= 8 {
+        Ok(n)
+    } else {
+        Err("precision NUM cannot be larger than eight".to_string())
     }
 }
 
@@ -411,7 +426,8 @@ fn process(args: Args) -> Result<(), String> {
 
     let xml_opt = usvg::XmlOptions {
         id_prefix: args.id_prefix,
-        num_n_decimal_places: args.num_n_decimal_places.unwrap_or(8),
+        coordinates_precision: args.coordinates_precision.unwrap_or(8),
+        transforms_precision: args.transforms_precision.unwrap_or(8),
         writer_opts: xmlwriter::Options {
             use_single_quote: false,
             indent: args.indent,

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -273,7 +273,7 @@ fn parse_length(s: &str) -> Result<u32, String> {
 fn parse_precision(s: &str) -> Result<u8, String> {
     let n: u8 = s.parse().map_err(|_| "invalid precision NUM value")?;
 
-    if !(2..=8).contains(&n) {
+    if (2..=8).contains(&n) {
         Ok(n)
     } else {
         Err("precision NUM cannot be smaller than 2 or larger than 8".to_string())

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -271,7 +271,7 @@ fn parse_length(s: &str) -> Result<u32, String> {
 }
 
 fn parse_precision(s: &str) -> Result<u8, String> {
-    let n: u8 = s.parse().map_err(|_| "invalid length")?;
+    let n: u8 = s.parse().map_err(|_| "invalid precision NUM value")?;
 
     if n <= 8 {
         Ok(n)

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -27,7 +27,7 @@ OPTIONS:
   -c                                Prints the output SVG to the stdout
 
   --dpi DPI                         Sets the resolution
-                                    [default: 96] [possible values: 10..4000]
+                                    [default: 96] [possible values: 10..4000 (inclusive)]
   --languages LANG                  Sets a comma-separated list of languages that
                                     will be used during the 'systemLanguage'
                                     attribute resolving
@@ -56,7 +56,7 @@ OPTIONS:
                                     [default: Times New Roman]
   --font-size SIZE                  Sets the default font size that will be
                                     used when no 'font-size' is present
-                                    [default: 12] [possible values: 1..192]
+                                    [default: 12] [possible values: 1..192 (inclusive)]
   --serif-family FAMILY             Sets the 'serif' font family.
                                     Will be used when no 'font-family' is present
                                     [default: Times New Roman]
@@ -86,10 +86,10 @@ OPTIONS:
                                     controls what size relative units in the document
                                     will use as a base if there is no viewBox and
                                     document width or height are relative.
-                                    [values: 1..2^32] [default: 100]
+                                    [values: 1..4294967295 (inclusive)] [default: 100]
   --default-height LENGTH           Sets the default height of the SVG viewport.
                                     Refer to the explanation of the '--default-width'
-                                    option. [values: 1..2^32] [default: 100]
+                                    option. [values: 1..4294967295 (inclusive)] [default: 100]
 
   --id-prefix                       Adds a prefix to each ID attribute
   --indent INDENT                   Sets the XML nodes indent
@@ -98,10 +98,10 @@ OPTIONS:
                                     [values: none, 0, 1, 2, 3, 4, tabs] [default: none]
   --coordinates-precision NUM       Set the coordinates numeric precision.
                                     Smaller precision can lead to a malformed output in some cases
-                                    [values: 2..8] [default: 8]
+                                    [values: 2..8 (inclusive)] [default: 8]
   --transforms-precision NUM        Set the transform values numeric precision.
                                     Smaller precision can lead to a malformed output in some cases
-                                    [values: 2..8] [default: 8]
+                                    [values: 2..8 (inclusive)] [default: 8]
   --quiet                           Disables warnings
 
 ARGS:

--- a/usvg/src/main.rs
+++ b/usvg/src/main.rs
@@ -273,10 +273,10 @@ fn parse_length(s: &str) -> Result<u32, String> {
 fn parse_precision(s: &str) -> Result<u8, String> {
     let n: u8 = s.parse().map_err(|_| "invalid precision NUM value")?;
 
-    if n <= 8 {
+    if !(2..=8).contains(&n) {
         Ok(n)
     } else {
-        Err("precision NUM cannot be larger than eight".to_string())
+        Err("precision NUM cannot be smaller than 2 or larger than 8".to_string())
     }
 }
 

--- a/usvg/src/writer.rs
+++ b/usvg/src/writer.rs
@@ -25,13 +25,26 @@ impl<T: Default + PartialEq + Copy> IsDefault for T {
 }
 
 /// XML writing options.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Debug)]
 pub struct XmlOptions {
     /// Used to add a custom prefix to each element ID during writing.
     pub id_prefix: Option<String>,
 
+    /// specifies the limit for decimal places when writing numbers.
+    pub num_n_decimal_places: u8,
+
     /// `xmlwriter` options.
     pub writer_opts: xmlwriter::Options,
+}
+
+impl Default for XmlOptions {
+    fn default() -> Self {
+        Self {
+            id_prefix: Default::default(),
+            num_n_decimal_places: 8,
+            writer_opts: Default::default(),
+        }
+    }
 }
 
 pub(crate) fn convert(tree: &Tree, opt: &XmlOptions) -> String {
@@ -497,7 +510,7 @@ fn conv_defs(tree: &Tree, opt: &XmlOptions, xml: &mut XmlWriter) {
                 xml.write_svg_attribute(AId::Y1, &lg.y1);
                 xml.write_svg_attribute(AId::X2, &lg.x2);
                 xml.write_svg_attribute(AId::Y2, &lg.y2);
-                write_base_grad(&lg.base, xml);
+                write_base_grad(&lg.base, xml, opt);
                 xml.end_element();
             }
             Paint::RadialGradient(rg) => {
@@ -508,7 +521,7 @@ fn conv_defs(tree: &Tree, opt: &XmlOptions, xml: &mut XmlWriter) {
                 xml.write_svg_attribute(AId::R, &rg.r.get());
                 xml.write_svg_attribute(AId::Fx, &rg.fx);
                 xml.write_svg_attribute(AId::Fy, &rg.fy);
-                write_base_grad(&rg.base, xml);
+                write_base_grad(&rg.base, xml, opt);
                 xml.end_element();
             }
             Paint::Pattern(pattern) => {
@@ -521,7 +534,7 @@ fn conv_defs(tree: &Tree, opt: &XmlOptions, xml: &mut XmlWriter) {
                     pattern.content_units,
                     Units::UserSpaceOnUse,
                 );
-                xml.write_transform(AId::PatternTransform, pattern.transform);
+                xml.write_transform(AId::PatternTransform, pattern.transform, opt);
 
                 if let Some(ref vbox) = pattern.view_box {
                     xml.write_viewbox(vbox);
@@ -542,7 +555,7 @@ fn conv_defs(tree: &Tree, opt: &XmlOptions, xml: &mut XmlWriter) {
         xml.start_svg_element(EId::ClipPath);
         xml.write_id_attribute(&clip.id, opt);
         xml.write_units(AId::ClipPathUnits, clip.units, Units::UserSpaceOnUse);
-        xml.write_transform(AId::Transform, clip.transform);
+        xml.write_transform(AId::Transform, clip.transform, opt);
 
         if let Some(ref clip) = clip.clip_path {
             xml.write_func_iri(AId::ClipPath, &clip.id, opt);
@@ -607,7 +620,7 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 }
             }
 
-            xml.write_transform(AId::Transform, img.transform);
+            xml.write_transform(AId::Transform, img.transform, opt);
             xml.write_image_data(&img.kind);
 
             xml.end_element();
@@ -661,7 +674,7 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 xml.write_svg_attribute(AId::Opacity, &g.opacity.get());
             }
 
-            xml.write_transform(AId::Transform, g.transform);
+            xml.write_transform(AId::Transform, g.transform, opt);
 
             if let Some(eb) = g.enable_background {
                 xml.write_enable_background(eb);
@@ -714,7 +727,7 @@ trait XmlWriterExt {
     fn write_viewbox(&mut self, view_box: &ViewBox);
     fn write_aspect(&mut self, aspect: AspectRatio);
     fn write_units(&mut self, id: AId, units: Units, def: Units);
-    fn write_transform(&mut self, id: AId, units: Transform);
+    fn write_transform(&mut self, id: AId, units: Transform, opt: &XmlOptions);
     fn write_enable_background(&mut self, eb: EnableBackground);
     fn write_visibility(&mut self, value: Visibility);
     fn write_func_iri(&mut self, aid: AId, id: &str, opt: &XmlOptions);
@@ -821,21 +834,21 @@ impl XmlWriterExt for XmlWriter {
         }
     }
 
-    fn write_transform(&mut self, id: AId, ts: Transform) {
+    fn write_transform(&mut self, id: AId, ts: Transform, opt: &XmlOptions) {
         if !ts.is_default() {
             self.write_attribute_raw(id.to_str(), |buf| {
                 buf.extend_from_slice(b"matrix(");
-                write_num(ts.a, buf);
+                write_num(ts.a, buf, opt.num_n_decimal_places);
                 buf.push(b' ');
-                write_num(ts.b, buf);
+                write_num(ts.b, buf, opt.num_n_decimal_places);
                 buf.push(b' ');
-                write_num(ts.c, buf);
+                write_num(ts.c, buf, opt.num_n_decimal_places);
                 buf.push(b' ');
-                write_num(ts.d, buf);
+                write_num(ts.d, buf, opt.num_n_decimal_places);
                 buf.push(b' ');
-                write_num(ts.e, buf);
+                write_num(ts.e, buf, opt.num_n_decimal_places);
                 buf.push(b' ');
-                write_num(ts.f, buf);
+                write_num(ts.f, buf, opt.num_n_decimal_places);
                 buf.extend_from_slice(b")");
             });
         }
@@ -1014,9 +1027,9 @@ fn has_xlink(tree: &Tree) -> bool {
     false
 }
 
-fn write_base_grad(g: &BaseGradient, xml: &mut XmlWriter) {
+fn write_base_grad(g: &BaseGradient, xml: &mut XmlWriter, opt: &XmlOptions) {
     xml.write_units(AId::GradientUnits, g.units, Units::ObjectBoundingBox);
-    xml.write_transform(AId::GradientTransform, g.transform);
+    xml.write_transform(AId::GradientTransform, g.transform, opt);
 
     match g.spread_method {
         SpreadMethod::Pad => {}
@@ -1069,23 +1082,23 @@ fn write_path(
         xml.write_func_iri(AId::ClipPath, id, opt);
     }
 
-    xml.write_transform(AId::Transform, path.transform);
+    xml.write_transform(AId::Transform, path.transform, opt);
 
     xml.write_attribute_raw("d", |buf| {
         for seg in path.data.segments() {
             match seg {
                 PathSegment::MoveTo { x, y } => {
                     buf.extend_from_slice(b"M ");
-                    write_num(x, buf);
+                    write_num(x, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(y, buf);
+                    write_num(y, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
                 }
                 PathSegment::LineTo { x, y } => {
                     buf.extend_from_slice(b"L ");
-                    write_num(x, buf);
+                    write_num(x, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(y, buf);
+                    write_num(y, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
                 }
                 PathSegment::CurveTo {
@@ -1097,17 +1110,17 @@ fn write_path(
                     y,
                 } => {
                     buf.extend_from_slice(b"C ");
-                    write_num(x1, buf);
+                    write_num(x1, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(y1, buf);
+                    write_num(y1, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(x2, buf);
+                    write_num(x2, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(y2, buf);
+                    write_num(y2, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(x, buf);
+                    write_num(x, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
-                    write_num(y, buf);
+                    write_num(y, buf, opt.num_n_decimal_places);
                     buf.push(b' ');
                 }
                 PathSegment::ClosePath => {
@@ -1229,21 +1242,22 @@ fn write_light_source(light: &filter::LightSource, xml: &mut XmlWriter) {
     xml.end_element();
 }
 
-fn write_num(num: f64, buf: &mut Vec<u8>) {
+fn write_num(num: f64, buf: &mut Vec<u8>, num_n_decimal_places: u8) {
     // If number is an integer, it's faster to write it as i32.
     if num.fract().is_fuzzy_zero() {
         write!(buf, "{}", num as i32).unwrap();
         return;
     }
 
-    // Round numbers up to 8 digits to prevent writing
+    // Round numbers up to the specified n of decimal places to prevent writing
     // ugly numbers like 29.999999999999996.
     // It's not 100% correct, but differences are insignificant.
     //
     // Note that at least in Rust 1.64 the number formatting in debug and release modes
     // can be slightly different. So having a lower precision makes
     // our output and tests reproducible.
-    let v = (num * 100_000_000.0).round() / 100_000_000.0;
+    let v = (num * (10_u32.pow(num_n_decimal_places as u32) as f64)).round()
+        / (10_u32.pow(num_n_decimal_places as u32) as f64);
 
     write!(buf, "{}", v).unwrap();
 }

--- a/usvg/src/writer.rs
+++ b/usvg/src/writer.rs
@@ -31,11 +31,17 @@ pub struct XmlOptions {
     pub id_prefix: Option<String>,
 
     /// Set the coordinates numeric precision.
-    /// Smaller precision can lead to a malformed output in some cases
+    ///
+    /// Smaller precision can lead to a malformed output in some cases.
+    ///
+    /// Default: 8
     pub coordinates_precision: u8,
 
     /// Set the transform values numeric precision.
-    /// Smaller precision can lead to a malformed output in some cases
+    ///
+    /// Smaller precision can lead to a malformed output in some cases.
+    ///
+    /// Default: 8
     pub transforms_precision: u8,
 
     /// `xmlwriter` options.

--- a/usvg/src/writer.rs
+++ b/usvg/src/writer.rs
@@ -1249,7 +1249,7 @@ fn write_light_source(light: &filter::LightSource, xml: &mut XmlWriter) {
 }
 
 static POW_VEC: &'static [f64] = &[
-    0.0,
+    1.0,
     10.0,
     100.0,
     1_000.0,


### PR DESCRIPTION
This adds an Xml option to specify the number of decimal places when writing numbers. It replaces the hard-coded limit to 8 places. This is useful when one wants to reduce the size of the usvg-export Svg.

For usage with the Cli, I also added an optional `--num-n-decimal-places` arg, it falls back to `8` if not found.

