### PR TITLE
Fix broken link to tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ or our [SVG 2 changelog](https://github.com/RazrFalcon/resvg/blob/master/docs/sv
 
 [SVG Tiny 1.2](https://www.w3.org/TR/SVGTiny12/) is not supported and support is also not planned.
 
-Results of the [resvg test suite](./tests/README.md):
+Results of the [resvg test suite](https://github.com/RazrFalcon/resvg-test-suite):
 
 ![](./.github/chart.svg)
 


### PR DESCRIPTION
Fix the broken link for SVG test cases. Previously, the link pointed to the test directory in resvg (which is now located at https://github.com/RazrFalcon/resvg/tree/master/crates/resvg/tests#resvg-tests-vs-resvg-test-suite-tests), but I think that pointing to the test suite repo is more appropriate. After all, the discussion at https://github.com/RazrFalcon/resvg/tree/master/crates/resvg/tests#resvg-tests-vs-resvg-test-suite-tests says that the repo is the source of truth.