### PR TITLE
Remove `transform` attribute from images and paths

### DIFF
--- a/crates/resvg/src/filter/mod.rs
+++ b/crates/resvg/src/filter/mod.rs
@@ -1087,7 +1087,6 @@ fn apply_image(
 
             let uimage = usvg::Image {
                 id: String::new(),
-                transform: usvg::Transform::default(),
                 visibility: usvg::Visibility::Visible,
                 view_box,
                 rendering_mode: fe.rendering_mode,

--- a/crates/resvg/src/image.rs
+++ b/crates/resvg/src/image.rs
@@ -21,7 +21,6 @@ pub fn convert(image: &usvg::Image, children: &mut Vec<Node>) -> Option<BBoxes> 
     let object_bbox = image.view_box.rect.to_rect();
     let bboxes = BBoxes {
         object: usvg::BBox::from(object_bbox),
-        transformed_object: usvg::BBox::from(object_bbox),
         layer: usvg::BBox::from(object_bbox),
     };
 

--- a/crates/resvg/src/image.rs
+++ b/crates/resvg/src/image.rs
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use usvg::Transform;
 use crate::render::TinySkiaPixmapMutExt;
 use crate::tree::{BBoxes, Node, Tree};
 
@@ -13,7 +12,6 @@ pub enum ImageKind {
 }
 
 pub struct Image {
-    pub transform: tiny_skia::Transform,
     pub view_box: usvg::ViewBox,
     pub quality: tiny_skia::FilterQuality,
     pub kind: ImageKind,
@@ -48,7 +46,6 @@ pub fn convert(image: &usvg::Image, children: &mut Vec<Node>) -> Option<BBoxes> 
     };
 
     children.push(Node::Image(Image {
-        transform: Transform::default(),
         view_box: image.view_box,
         quality,
         kind,
@@ -85,7 +82,7 @@ fn render_vector(
     let mut sub_pixmap = tiny_skia::Pixmap::new(pixmap.width(), pixmap.height()).unwrap();
 
     let source_transform = transform;
-    let transform = transform.pre_concat(image.transform).pre_concat(ts);
+    let transform = transform.pre_concat(ts);
 
     tree.render(transform, &mut sub_pixmap.as_mut());
 
@@ -242,7 +239,6 @@ mod raster_images {
             None
         };
 
-        let transform = transform.pre_concat(image.transform);
         pixmap.fill_rect(rect.to_rect(), &paint, transform, mask.as_ref());
 
         Some(())

--- a/crates/resvg/src/image.rs
+++ b/crates/resvg/src/image.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use usvg::Transform;
 use crate::render::TinySkiaPixmapMutExt;
 use crate::tree::{BBoxes, Node, Tree};
 
@@ -22,7 +23,7 @@ pub fn convert(image: &usvg::Image, children: &mut Vec<Node>) -> Option<BBoxes> 
     let object_bbox = image.view_box.rect.to_rect();
     let bboxes = BBoxes {
         object: usvg::BBox::from(object_bbox),
-        transformed_object: usvg::BBox::from(object_bbox.transform(image.transform)?),
+        transformed_object: usvg::BBox::from(object_bbox),
         layer: usvg::BBox::from(object_bbox),
     };
 
@@ -47,7 +48,7 @@ pub fn convert(image: &usvg::Image, children: &mut Vec<Node>) -> Option<BBoxes> 
     };
 
     children.push(Node::Image(Image {
-        transform: image.transform,
+        transform: Transform::default(),
         view_box: image.view_box,
         quality,
         kind,

--- a/crates/resvg/src/path.rs
+++ b/crates/resvg/src/path.rs
@@ -59,8 +59,6 @@ pub fn convert(upath: &usvg::Path, children: &mut Vec<Node>) -> Option<BBoxes> {
         bboxes.object = bboxes.object.expand(o_bbox);
     }
 
-    bboxes.transformed_object = bboxes.object.transform(Transform::default())?;
-
     // Do not add hidden paths, but preserve the bbox.
     // visibility=hidden still affects the bbox calculation.
     if upath.visibility != usvg::Visibility::Visible {

--- a/crates/resvg/src/path.rs
+++ b/crates/resvg/src/path.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::rc::Rc;
+use usvg::Transform;
 
 use crate::paint_server::Paint;
 use crate::render::Context;
@@ -25,7 +26,7 @@ pub struct StrokePath {
 }
 
 pub fn convert(upath: &usvg::Path, children: &mut Vec<Node>) -> Option<BBoxes> {
-    let transform = upath.transform;
+    let transform = Transform::default();
     let anti_alias = upath.rendering_mode.use_shape_antialiasing();
 
     let fill_path = upath.fill.as_ref().and_then(|ufill| {
@@ -63,7 +64,7 @@ pub fn convert(upath: &usvg::Path, children: &mut Vec<Node>) -> Option<BBoxes> {
         bboxes.object = bboxes.object.expand(o_bbox);
     }
 
-    bboxes.transformed_object = bboxes.object.transform(upath.transform)?;
+    bboxes.transformed_object = bboxes.object.transform(Transform::default())?;
 
     // Do not add hidden paths, but preserve the bbox.
     // visibility=hidden still affects the bbox calculation.

--- a/crates/resvg/src/path.rs
+++ b/crates/resvg/src/path.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::rc::Rc;
-use usvg::Transform;
 
 use crate::paint_server::Paint;
 use crate::render::Context;
@@ -164,9 +163,7 @@ fn convert_stroke_path(
 
     // TODO: explain
     // TODO: expand by stroke width for round/bevel joins
-    let resolution_scale = tiny_skia::PathStroker::compute_resolution_scale(&Transform::default());
-    let resolution_scale = resolution_scale.max(10.0);
-    let stroked_path = path.stroke(&stroke, resolution_scale)?;
+    let stroked_path = path.stroke(&stroke, 1.0)?;
 
     let mut layer_bbox = usvg::BBox::from(stroked_path.bounds());
     if let Some(text_bbox) = text_bbox {

--- a/crates/resvg/src/tree.rs
+++ b/crates/resvg/src/tree.rs
@@ -139,9 +139,6 @@ pub struct BBoxes {
     /// Just a shape/image bbox as per SVG spec.
     pub object: usvg::BBox,
 
-    /// The same as above, but transformed using object's transform.
-    pub transformed_object: usvg::BBox,
-
     /// Similar to `object`, but expanded to fit the stroke as well.
     pub layer: usvg::BBox,
 }
@@ -167,7 +164,7 @@ fn convert_group(
     };
 
     let (filters, filter_bbox) =
-        crate::filter::convert(&ugroup.filters, bboxes.transformed_object.to_rect());
+        crate::filter::convert(&ugroup.filters, bboxes.object.to_rect());
 
     // TODO: figure out a nicer solution
     // Ignore groups with filters but invalid filter bboxes.
@@ -192,7 +189,6 @@ fn convert_group(
     };
 
     bboxes.object = bboxes.object.transform(ugroup.transform)?;
-    bboxes.transformed_object = bboxes.transformed_object.transform(ugroup.transform)?;
     bboxes.layer = bboxes.layer.transform(ugroup.transform)?;
 
     children.push(Node::Group(group));
@@ -222,7 +218,6 @@ fn convert_empty_group(ugroup: &usvg::Group, children: &mut Vec<Node>) -> Option
     let bboxes = BBoxes {
         // TODO: find a better solution
         object: usvg::BBox::default(),
-        transformed_object: usvg::BBox::default(),
         layer: usvg::BBox::from(layer_bbox),
     };
 
@@ -236,8 +231,6 @@ fn convert_children(parent: usvg::Node, children: &mut Vec<Node>) -> Option<BBox
     for node in parent.children() {
         if let Some(bboxes2) = convert_node_inner(node, children) {
             bboxes.object = bboxes.object.expand(bboxes2.object);
-            bboxes.transformed_object =
-                bboxes.transformed_object.expand(bboxes2.transformed_object);
             bboxes.layer = bboxes.layer.expand(bboxes2.layer);
         }
     }

--- a/crates/usvg-parser/src/converter.rs
+++ b/crates/usvg-parser/src/converter.rs
@@ -687,7 +687,6 @@ fn convert_path(
 
     parent.append_kind(NodeKind::Path(Path {
         id,
-        transform: Default::default(),
         visibility,
         fill,
         stroke,

--- a/crates/usvg-parser/src/image.rs
+++ b/crates/usvg-parser/src/image.rs
@@ -173,7 +173,6 @@ pub(crate) fn convert(node: SvgNode, state: &converter::State, parent: &mut Node
 
     parent.append_kind(NodeKind::Image(Image {
         id,
-        transform: Default::default(),
         visibility,
         view_box,
         rendering_mode,

--- a/crates/usvg-parser/src/text.rs
+++ b/crates/usvg-parser/src/text.rs
@@ -108,7 +108,6 @@ pub(crate) fn convert(
 
     let text = Text {
         id,
-        transform: Transform::default(),
         rendering_mode,
         positions: pos_list,
         rotate: rotate_list,

--- a/crates/usvg-text-layout/src/lib.rs
+++ b/crates/usvg-text-layout/src/lib.rs
@@ -62,7 +62,6 @@ impl TextToPath for Text {
         // Create a group will all paths that was created during text-to-path conversion.
         let group = Node::new(NodeKind::Group(Group {
             id: self.id.clone(),
-            transform: self.transform,
             ..Group::default()
         }));
 
@@ -95,8 +94,7 @@ fn convert_text(root: Node, fontdb: &fontdb::Database) {
     for node in &text_nodes {
         let mut new_node = None;
         if let NodeKind::Text(ref text) = *node.borrow() {
-            let mut absolute_ts = node.parent().unwrap().abs_transform();
-            absolute_ts = absolute_ts.pre_concat(text.transform);
+            let absolute_ts = node.parent().unwrap().abs_transform();
             new_node = text.convert(fontdb, absolute_ts);
         }
 

--- a/crates/usvg-text-layout/src/lib.rs
+++ b/crates/usvg-text-layout/src/lib.rs
@@ -707,7 +707,6 @@ fn convert_span(
 
     let path = Path {
         id: String::new(),
-        transform: Transform::default(),
         visibility: span.visibility,
         fill,
         stroke: span.stroke.clone(),

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -737,8 +737,8 @@ impl NodeKind {
     pub fn transform(&self) -> Transform {
         match self {
             NodeKind::Group(ref e) => e.transform,
-            NodeKind::Path(ref e) => Transform::default(),
-            NodeKind::Image(ref e) => Transform::default(),
+            NodeKind::Path(_) => Transform::default(),
+            NodeKind::Image(_) => Transform::default(),
             NodeKind::Text(ref e) => e.transform,
         }
     }

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -738,7 +738,7 @@ impl NodeKind {
         match self {
             NodeKind::Group(ref e) => e.transform,
             NodeKind::Path(ref e) => Transform::default(),
-            NodeKind::Image(ref e) => e.transform,
+            NodeKind::Image(ref e) => Transform::default(),
             NodeKind::Text(ref e) => e.transform,
         }
     }
@@ -935,9 +935,6 @@ pub struct Image {
     /// Isn't automatically generated.
     /// Can be empty.
     pub id: String,
-
-    /// Element transform.
-    pub transform: Transform,
 
     /// Element visibility.
     pub visibility: Visibility,

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -737,7 +737,7 @@ impl NodeKind {
     pub fn transform(&self) -> Transform {
         match self {
             NodeKind::Group(ref e) => e.transform,
-            NodeKind::Path(ref e) => e.transform,
+            NodeKind::Path(ref e) => Transform::default(),
             NodeKind::Image(ref e) => e.transform,
             NodeKind::Text(ref e) => e.transform,
         }
@@ -844,9 +844,6 @@ pub struct Path {
     /// Can be empty.
     pub id: String,
 
-    /// Element transform.
-    pub transform: Transform,
-
     /// Element visibility.
     pub visibility: Visibility,
 
@@ -892,7 +889,6 @@ impl Path {
     pub fn new(data: Rc<tiny_skia_path::Path>) -> Self {
         Path {
             id: String::new(),
-            transform: Transform::default(),
             visibility: Visibility::Visible,
             fill: None,
             stroke: None,

--- a/crates/usvg-tree/src/lib.rs
+++ b/crates/usvg-tree/src/lib.rs
@@ -739,7 +739,7 @@ impl NodeKind {
             NodeKind::Group(ref e) => e.transform,
             NodeKind::Path(_) => Transform::default(),
             NodeKind::Image(_) => Transform::default(),
-            NodeKind::Text(ref e) => e.transform,
+            NodeKind::Text(_) => Transform::default(),
         }
     }
 }

--- a/crates/usvg-tree/src/text.rs
+++ b/crates/usvg-tree/src/text.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 
 use strict_num::NonZeroPositiveF32;
 
-use crate::{Fill, PaintOrder, Stroke, TextRendering, Transform, Visibility};
+use crate::{Fill, PaintOrder, Stroke, TextRendering, Visibility};
 
 /// A font stretch property.
 #[allow(missing_docs)]
@@ -311,9 +311,6 @@ pub struct Text {
     /// Isn't automatically generated.
     /// Can be empty.
     pub id: String,
-
-    /// Element transform.
-    pub transform: Transform,
 
     /// Rendering mode.
     ///

--- a/crates/usvg/docs/spec.adoc
+++ b/crates/usvg/docs/spec.adoc
@@ -329,7 +329,8 @@ A group will have at least one of the attributes present.
   Default: geometricPrecision
 * `visibility` = `hidden | collapse`? +
   Default: visible
-* `transform` = <<transform-type,<transform> >>?
+* `transform` = <<transform-type,<transform> >>? +
+  Can only be set on paths inside of `clipPath`.
 
 [[image-element]]
 
@@ -354,7 +355,6 @@ A group will have at least one of the attributes present.
   Default: optimizeQuality
 * `visibility` = `hidden | collapse`? +
   Default: visible
-* `transform` = <<transform-type,<transform> >>?
 
 == Filter primitives
 

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -585,7 +585,6 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 }
             }
 
-            xml.write_transform(AId::Transform, img.transform, opt);
             xml.write_image_data(&img.kind);
 
             xml.end_element();

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -563,7 +563,7 @@ fn conv_elements(parent: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut 
 fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut XmlWriter) {
     match *node.borrow() {
         NodeKind::Path(ref p) => {
-            write_path(p, is_clip_path, None, opt, xml);
+            write_path(p, is_clip_path, Transform::default(), None, opt, xml);
         }
         NodeKind::Image(ref img) => {
             xml.start_svg_element(EId::Image);
@@ -596,11 +596,10 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 // `clip-path` on it.
 
                 if let NodeKind::Path(ref path) = *node.first_child().unwrap().borrow() {
-                    //TODO: verify
                     let path = path.clone();
 
                     let clip_id = g.clip_path.as_ref().map(|cp| cp.id.as_str());
-                    write_path(&path, is_clip_path, clip_id, opt, xml);
+                    write_path(&path, is_clip_path, g.transform, clip_id, opt, xml);
                 }
 
                 return;
@@ -982,6 +981,7 @@ fn write_base_grad(g: &BaseGradient, xml: &mut XmlWriter, opt: &XmlOptions) {
 fn write_path(
     path: &Path,
     is_clip_path: bool,
+    path_transform: Transform,
     clip_path: Option<&str>,
     opt: &XmlOptions,
     xml: &mut XmlWriter,
@@ -1012,7 +1012,7 @@ fn write_path(
         xml.write_func_iri(AId::ClipPath, id, opt);
     }
 
-    xml.write_transform(AId::Transform, Transform::default(), opt);
+    xml.write_transform(AId::Transform, path_transform, opt);
 
     xml.write_attribute_raw("d", |buf| {
         use tiny_skia_path::PathSegment;

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -597,8 +597,8 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
                 // `clip-path` on it.
 
                 if let NodeKind::Path(ref path) = *node.first_child().unwrap().borrow() {
-                    let mut path = path.clone();
-                    path.transform = g.transform.pre_concat(path.transform);
+                    //TODO: verify
+                    let path = path.clone();
 
                     let clip_id = g.clip_path.as_ref().map(|cp| cp.id.as_str());
                     write_path(&path, is_clip_path, clip_id, opt, xml);
@@ -1013,7 +1013,7 @@ fn write_path(
         xml.write_func_iri(AId::ClipPath, id, opt);
     }
 
-    xml.write_transform(AId::Transform, path.transform, opt);
+    xml.write_transform(AId::Transform, Transform::default(), opt);
 
     xml.write_attribute_raw("d", |buf| {
         use tiny_skia_path::PathSegment;


### PR DESCRIPTION
Since all transforms on paths and images will be added in the form as a group, we won't really need them on `Image` and `Path` anymore. This makes the tree a bit simpler.

I hope I didn't miss anything.