### PR TITLE
2 fixes for usvg Tree writer

### DIFF
--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -592,9 +592,13 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
         NodeKind::Group(ref g) => {
             if is_clip_path {
                 // ClipPath with a Group element is an `usvg` special case.
-                // Group will contain a sequence of path elements and we should set
+                // Group will contain a single path element and we should set
                 // `clip-path` on it.
 
+                // TODO: As mentioned above, if it is a group element it should only contain a
+                // single path element. However when converting text nodes to path, multiple
+                // paths might be present. As a temporary workaround, we just loop over all
+                // children instead.
                 for child in node.children() {
                     if let NodeKind::Path(ref path) = *child.borrow() {
                         let path = path.clone();

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -592,11 +592,11 @@ fn conv_element(node: &Node, is_clip_path: bool, opt: &XmlOptions, xml: &mut Xml
         NodeKind::Group(ref g) => {
             if is_clip_path {
                 // ClipPath with a Group element is an `usvg` special case.
-                // Group will contain a single Path element and we should set
+                // Group will contain a sequence of path elements and we should set
                 // `clip-path` on it.
 
-                if let Some(node) = node.first_child() {
-                    if let NodeKind::Path(ref path) = *node.borrow() {
+                for child in node.children() {
+                    if let NodeKind::Path(ref path) = *child.borrow() {
                         let path = path.clone();
 
                         let clip_id = g.clip_path.as_ref().map(|cp| cp.id.as_str());


### PR DESCRIPTION
Firstly, I fixed an issue where a call to `.unwrap` would cause a panic with the following svg file (from the test suite):

```svg
 <svg id="svg1" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"
     xmlns:xlink="http://www.w3.org/1999/xlink">
    <title>With invalid child via `use`</title>

    <defs id="defs1">
        <g id="g1">
            <path id="path1" d="M 100 15 l 50 160 l -130 -100 l 160 0 l -130 100 z"/>
        </g>
        <clipPath id="clip1">
            <use id="use1" xlink:href="#g1"/>
        </clipPath>
    </defs>
    <rect id="rect1" x="0" y="0" width="200" height="200" fill="red" clip-path="url(#clip1)"/>

    <!-- image frame -->
    <rect id="frame" x="1" y="1" width="198" height="198" fill="none" stroke="black"/>
</svg>
````
I guess it's not really relevant since it's invalid, but I would say it's still better to just ignore it than let it crash in that case.

Secondly, the writer failed to write the `xmlns:xlink` attribute for images inside of masks because they weren't checked properly.