### PR TITLE
Make `pico-args` a binary-only dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "crates/resvg",
     "crates/usvg",

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -12,13 +12,13 @@ workspace = "../.."
 
 [[bin]]
 name = "resvg"
-required-features = ["text", "system-fonts", "memmap-fonts"]
+required-features = ["text", "system-fonts", "memmap-fonts", "pico-args"]
 
 [dependencies]
 gif = { version = "0.12", optional = true }
 jpeg-decoder = { version = "0.3", default-features = false, features = ["platform_independent"], optional = true }
 log = "0.4"
-pico-args = { version = "0.5", features = ["eq-separator"] }
+pico-args = { version = "0.5", optional = true, features = ["eq-separator"] }
 png = { version = "0.17", optional = true }
 rgb = "0.8"
 svgtypes = { git = "https://github.com/RazrFalcon/svgtypes" }

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -15,12 +15,12 @@ workspace = "../.."
 
 [[bin]]
 name = "usvg"
-required-features = ["text", "system-fonts", "memmap-fonts"]
+required-features = ["text", "system-fonts", "memmap-fonts", "pico-args"]
 
 [dependencies]
 base64 = "0.21" # for embedded images
 log = "0.4"
-pico-args = { version = "0.5", features = ["eq-separator"] }
+pico-args = { version = "0.5", optional = true, features = ["eq-separator"] }
 usvg-parser = { path = "../usvg-parser", version = "0.36.0" }
 usvg-tree = { path = "../usvg-tree", version = "0.36.0" }
 xmlwriter = "0.1"


### PR DESCRIPTION
This library currently includes `pico-args` as a dependency, but this is very much a binary-specific dependency
Thus I've made it optional, and added as a feature to the binary.

This will make this library less congested with non-library things.

In addition, `resolver = "2"` was set, as this isn't the case for workspaces,
it is the case for crates falling under 2021 editions -- but not workspaces.

