### PR TITLE
Add copyright notice to LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+Copyright (C) 2017-2024 Yevhenii Reizner. All Rights Reserved.
+
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
Fixes #697

A valid copyright notice is required to pass the Volkswagen Group open source validation so that they can use this project as part of Rhino software (www.rhino3d.com).