### PR TITLE
usvg: update kurbo to sync dep version with svgtypes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,15 +143,6 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "kurbo"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "kurbo"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
@@ -331,7 +322,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d7618f12b51be8171a7cfdda1e7a93f79cbc57c4e7adf89a749cf671125241"
 dependencies = [
- "kurbo 0.10.4",
+ "kurbo",
  "siphasher",
 ]
 
@@ -427,7 +418,7 @@ dependencies = [
  "flate2",
  "fontdb",
  "imagesize",
- "kurbo 0.9.5",
+ "kurbo",
  "log",
  "once_cell",
  "pico-args",

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -30,7 +30,7 @@ xmlwriter = "0.1"
 data-url = "0.3" # for href parsing
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] } # SVGZ decoding
 imagesize = "0.12" # raster images size detection
-kurbo = "0.9" # Bezier curves utils
+kurbo = "0.10" # Bezier curves utils, try to keep in sync with svgtypes crate
 roxmltree = "0.19"
 simplecss = "0.2"
 siphasher = "0.3" # perfect hash implementation


### PR DESCRIPTION
Context: https://github.com/emilk/egui/pull/4194

This prevents usvg from depending on two different versions of kurbo.

![image](https://github.com/RazrFalcon/resvg/assets/6328589/c07c8489-776c-4da3-8cd3-0b74aaab5cc0)



