### PR TITLE
Add text corresponding to layouted glyph

### DIFF
--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -1468,6 +1468,7 @@ pub(crate) struct Glyph {
     /// We use it to match a glyph with a character in the text chunk and therefore with the style.
     pub(crate) byte_idx: ByteIndex,
 
+    /// The text from the original string that corresponds to that glyph.
     pub(crate) text: String,
 
     /// The glyph offset in font units.

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -1318,9 +1318,9 @@ fn shape_text_with_font(
                 let info = infos[i];
                 let idx = run.start + info.cluster as usize;
 
-                let mut start = info.cluster as usize;
+                let start = info.cluster as usize;
 
-                let mut end = if ltr { i.checked_add(1) } else { i.checked_sub(1) }
+                let end = if ltr { i.checked_add(1) } else { i.checked_sub(1) }
                     .and_then(|last| infos.get(last))
                     .map_or(sub_text.len(), |info| info.cluster as usize);
 


### PR DESCRIPTION
What do you think of this? I basically adapted it from https://github.com/typst/typst/blob/105d7156f8f9d95e16b3eefdf0fa97e5be7fbe5b/crates/typst/src/layout/inline/shaping.rs#L729-L733

I also checked and I've managed to get copyable text to work (in `svg2pdf`), I also tried it with other scripts (like Arabic) and it seems to work!