### PR TITLE
fix: print error messages to stderr

### DIFF
--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -494,15 +494,15 @@ fn parse_args() -> Result<Args, String> {
     }
 
     if args.input == "-" && args.resources_dir.is_none() {
-        println!("Warning: Make sure to set --resources-dir when reading SVG from stdin.");
+        eprintln!("Warning: Make sure to set --resources-dir when reading SVG from stdin.");
     }
 
     if args.export_area_page && args.export_id.is_none() {
-        println!("Warning: --export-area-page has no effect without --export-id.");
+        eprintln!("Warning: --export-area-page has no effect without --export-id.");
     }
 
     if args.export_area_drawing && args.export_id.is_some() {
-        println!("Warning: --export-area-drawing has no effect when --export-id is set.");
+        eprintln!("Warning: --export-area-drawing has no effect when --export-id is set.");
     }
 
     let export_id = args.export_id.as_ref().map(|v| v.to_string());


### PR DESCRIPTION
Using the following command will cause a warning message to be written to the png file
```bash
cat ./test.svg | resvg - -c > test.png
```

test.png
```
Warning: Make sure to set --resources-dir when reading SVG from stdin.
�PNG

```


Removed the colon for consistency in error messages.
```
Warning Make sure to set --resources-dir when reading SVG from stdin.
Warning (in fontdb:241): Failed to load a font face 0 from 'C:\Windows\Fonts\mstmc.ttf' cause malformed font.
Warning (in usvg::text::layout:1551): Fallback from Times New Roman to Cascadia Code.
Warning (in usvg::text::layout:1551): Fallback from Courier New to Cascadia Code.
Warning (in usvg::text::layout:1551): Fallback from Times New Roman to Cascadia Code.
```