### PR TITLE
Give the user more flexibility over font selection

### DIFF
--- a/crates/resvg/examples/custom_href_resolver.rs
+++ b/crates/resvg/examples/custom_href_resolver.rs
@@ -5,13 +5,13 @@ fn main() {
 
     // We know that our SVG won't have DataUrl hrefs, just return None for such case.
     let resolve_data = Box::new(
-        |_: &str, _: std::sync::Arc<Vec<u8>>, _: &usvg::Options, _: &usvg::fontdb::Database| None,
+        |_: &str, _: std::sync::Arc<Vec<u8>>, _: &usvg::Options, _: &dyn usvg::FontProvider| None,
     );
 
     // Here we handle xlink:href attribute as string,
     // let's use already loaded Ferris image to match that string.
     let resolve_string = Box::new(
-        move |href: &str, _: &usvg::Options, _: &usvg::fontdb::Database| match href {
+        move |href: &str, _: &usvg::Options, _: &dyn usvg::FontProvider| match href {
             "ferris_image" => Some(usvg::ImageKind::PNG(ferris_image.clone())),
             _ => None,
         },

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use once_cell::sync::Lazy;
 use rgb::{FromSlice, RGBA8};
 use std::process::Command;
@@ -40,7 +41,7 @@ pub fn render(name: &str) -> usize {
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();
         let db = GLOBAL_FONTDB.lock().unwrap();
-        usvg::Tree::from_data(&svg_data, &opt, &db).unwrap()
+        usvg::Tree::from_data(&svg_data, &opt, db.deref()).unwrap()
     };
 
     let size = tree
@@ -95,7 +96,7 @@ pub fn render_extra_with_scale(name: &str, scale: f32) -> usize {
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();
         let db = GLOBAL_FONTDB.lock().unwrap();
-        usvg::Tree::from_data(&svg_data, &opt, &db).unwrap()
+        usvg::Tree::from_data(&svg_data, &opt, db.deref()).unwrap()
     };
 
     let size = tree.size().to_int_size().scale_by(scale).unwrap();
@@ -145,7 +146,7 @@ pub fn render_node(name: &str, id: &str) -> usize {
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();
         let db = GLOBAL_FONTDB.lock().unwrap();
-        usvg::Tree::from_data(&svg_data, &opt, &db).unwrap()
+        usvg::Tree::from_data(&svg_data, &opt, db.deref()).unwrap()
     };
 
     let node = tree.node_by_id(id).unwrap();

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -1,6 +1,6 @@
-use std::ops::Deref;
 use once_cell::sync::Lazy;
 use rgb::{FromSlice, RGBA8};
+use std::ops::Deref;
 use std::process::Command;
 use usvg::fontdb;
 

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -31,7 +31,7 @@ pub struct State<'a> {
     pub(crate) use_size: (Option<f32>, Option<f32>),
     pub(crate) opt: &'a Options,
     #[cfg(feature = "text")]
-    pub(crate) fontdb: &'a fontdb::Database,
+    pub(crate) font_provider: &'a dyn FontProvider,
 }
 
 #[derive(Clone, Default)]
@@ -260,14 +260,14 @@ impl SvgColorExt for svgtypes::Color {
 pub(crate) fn convert_doc(
     svg_doc: &svgtree::Document,
     opt: &Options,
-    #[cfg(feature = "text")] fontdb: &fontdb::Database,
+    #[cfg(feature = "text")] font_provider: &dyn FontProvider,
 ) -> Result<Tree, Error> {
     let svg = svg_doc.root_element();
     let (size, restore_viewbox) = resolve_svg_size(
         &svg,
         opt,
         #[cfg(feature = "text")]
-        fontdb,
+        font_provider,
     );
     let size = size?;
     let view_box = ViewBox {
@@ -301,7 +301,7 @@ pub(crate) fn convert_doc(
         use_size: (None, None),
         opt,
         #[cfg(feature = "text")]
-        fontdb,
+        font_provider,
     };
 
     let mut cache = Cache::default();
@@ -365,7 +365,7 @@ pub(crate) fn convert_doc(
 fn resolve_svg_size(
     svg: &SvgNode,
     opt: &Options,
-    #[cfg(feature = "text")] fontdb: &fontdb::Database,
+    #[cfg(feature = "text")] font_provider: &dyn FontProvider,
 ) -> (Result<Size, Error>, bool) {
     let mut state = State {
         parent_clip_path: None,
@@ -376,7 +376,7 @@ fn resolve_svg_size(
         use_size: (None, None),
         opt,
         #[cfg(feature = "text")]
-        fontdb,
+        font_provider,
     };
 
     let def = Length::new(100.0, Unit::Percent);

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -6,10 +6,13 @@ use std::sync::Arc;
 
 use svgtypes::{AspectRatio, Length};
 
+#[cfg(feature = "text")]
+use crate::FontProvider;
+
 use super::svgtree::{AId, SvgNode};
 use super::{converter, OptionLog, Options};
 use crate::{
-    ClipPath, FontProvider, Group, Image, ImageKind, ImageRendering, Node, NonZeroRect, Path, Size,
+    ClipPath, Group, Image, ImageKind, ImageRendering, Node, NonZeroRect, Path, Size,
     Transform, Tree, Visibility,
 };
 

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -20,6 +20,7 @@ mod use_node;
 #[cfg(feature = "text")]
 mod text;
 
+use crate::FontProvider;
 pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn};
 pub use options::Options;
 pub(crate) use svgtree::{AId, EId};
@@ -98,7 +99,7 @@ impl crate::Tree {
     pub fn from_data(
         data: &[u8],
         opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
+        #[cfg(feature = "text")] font_provider: &dyn FontProvider,
     ) -> Result<Self, Error> {
         if data.starts_with(&[0x1f, 0x8b]) {
             let data = decompress_svgz(data)?;
@@ -107,7 +108,7 @@ impl crate::Tree {
                 text,
                 opt,
                 #[cfg(feature = "text")]
-                fontdb,
+                font_provider,
             )
         } else {
             let text = std::str::from_utf8(data).map_err(|_| Error::NotAnUtf8Str)?;
@@ -115,7 +116,7 @@ impl crate::Tree {
                 text,
                 opt,
                 #[cfg(feature = "text")]
-                fontdb,
+                font_provider,
             )
         }
     }
@@ -124,7 +125,7 @@ impl crate::Tree {
     pub fn from_str(
         text: &str,
         opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
+        #[cfg(feature = "text")] font_provider: &dyn FontProvider,
     ) -> Result<Self, Error> {
         let xml_opt = roxmltree::ParsingOptions {
             allow_dtd: true,
@@ -138,7 +139,7 @@ impl crate::Tree {
             &doc,
             opt,
             #[cfg(feature = "text")]
-            fontdb,
+            font_provider,
         )
     }
 
@@ -146,14 +147,14 @@ impl crate::Tree {
     pub fn from_xmltree(
         doc: &roxmltree::Document,
         opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
+        #[cfg(feature = "text")] font_provider: &dyn FontProvider,
     ) -> Result<Self, Error> {
         let doc = svgtree::Document::parse_tree(doc)?;
         self::converter::convert_doc(
             &doc,
             opt,
             #[cfg(feature = "text")]
-            fontdb,
+            font_provider,
         )
     }
 }

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -19,7 +19,7 @@ mod use_node;
 
 #[cfg(feature = "text")]
 mod text;
-
+#[cfg(feature = "text")]
 use crate::FontProvider;
 pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn};
 pub use options::Options;

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -141,7 +141,7 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, state.fontdb).is_none() {
+    if text::convert(&mut text, state.font_provider).is_none() {
         return;
     }
 

--- a/crates/usvg/src/text/flatten.rs
+++ b/crates/usvg/src/text/flatten.rs
@@ -44,7 +44,7 @@ fn push_outline_paths(
     }
 }
 
-pub(crate) fn flatten(text: &mut Text, fontdb: &fontdb::Database) -> Option<(Group, NonZeroRect)> {
+pub(crate) fn flatten<T, RF: ResolvedFont<T>>(text: &mut Text, font_provider: &impl FontProvider<T, RF>) -> Option<(Group, NonZeroRect)> {
     let mut new_children = vec![];
 
     let rendering_mode = resolve_rendering_mode(text);

--- a/crates/usvg/src/text/fontdb.rs
+++ b/crates/usvg/src/text/fontdb.rs
@@ -1,14 +1,10 @@
-use std::num::NonZeroU16;
+use crate::{Font, FontProvider, FontStretch, FontStyle, ResolvedFont};
 use fontdb::{Database, ID};
 use rustybuzz::ttf_parser;
+use std::num::NonZeroU16;
 use svgtypes::FontFamily;
-use crate::{Font, FontProvider, FontStretch, FontStyle, ResolvedFont};
 
 impl FontProvider for Database {
-    fn with_face_data<P, T>(&self, id: fontdb::ID, p: P) -> Option<T> where P: FnOnce(&[u8], u32) -> T {
-        self.with_face_data(id, p)
-    }
-
     fn resolve_font(&self, font: &Font) -> Option<ResolvedFont> {
         let mut name_list = Vec::new();
         for family in &font.families {
@@ -53,13 +49,13 @@ impl FontProvider for Database {
         let id = self.query(&query);
         if id.is_none() {
             log::warn!(
-            "No match for '{}' font-family.",
-            font.families
-                .iter()
-                .map(|f| f.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
+                "No match for '{}' font-family.",
+                font.families
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
         }
 
         self.load_font(id?)
@@ -105,6 +101,10 @@ impl FontProvider for Database {
         }
 
         None
+    }
+
+    fn fontdb(&self) -> &Database {
+        &self
     }
 }
 

--- a/crates/usvg/src/text/fontdb.rs
+++ b/crates/usvg/src/text/fontdb.rs
@@ -1,0 +1,265 @@
+use std::num::NonZeroU16;
+use fontdb::{Database, ID};
+use rustybuzz::ttf_parser;
+use svgtypes::FontFamily;
+use crate::{Font, FontProvider, FontStretch, FontStyle, ResolvedFont};
+
+impl FontProvider<ID, FontDBResolvedFont> for Database {
+    fn with_face_data<P, T>(&self, id: fontdb::ID, p: P) -> Option<T> where P: FnOnce(&[u8], u32) -> T {
+        self.with_face_data(id, p)
+    }
+
+    fn resolve_font(&self, font: &Font) -> Option<FontDBResolvedFont> {
+        let mut name_list = Vec::new();
+        for family in &font.families {
+            name_list.push(match family {
+                FontFamily::Serif => fontdb::Family::Serif,
+                FontFamily::SansSerif => fontdb::Family::SansSerif,
+                FontFamily::Cursive => fontdb::Family::Cursive,
+                FontFamily::Fantasy => fontdb::Family::Fantasy,
+                FontFamily::Monospace => fontdb::Family::Monospace,
+                FontFamily::Named(s) => fontdb::Family::Name(s),
+            });
+        }
+
+        // Use the default font as fallback.
+        name_list.push(fontdb::Family::Serif);
+
+        let stretch = match font.stretch {
+            FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
+            FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
+            FontStretch::Condensed => fontdb::Stretch::Condensed,
+            FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
+            FontStretch::Normal => fontdb::Stretch::Normal,
+            FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
+            FontStretch::Expanded => fontdb::Stretch::Expanded,
+            FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
+            FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
+        };
+
+        let style = match font.style {
+            FontStyle::Normal => fontdb::Style::Normal,
+            FontStyle::Italic => fontdb::Style::Italic,
+            FontStyle::Oblique => fontdb::Style::Oblique,
+        };
+
+        let query = fontdb::Query {
+            families: &name_list,
+            weight: fontdb::Weight(font.weight),
+            stretch,
+            style,
+        };
+
+        let id = self.query(&query);
+        if id.is_none() {
+            log::warn!(
+            "No match for '{}' font-family.",
+            font.families
+                .iter()
+                .map(|f| f.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        }
+
+        self.load_font(id?)
+    }
+
+    fn find_font_for_char(&self, c: char, exclude_fonts: &[ID]) -> Option<FontDBResolvedFont> {
+        let base_font_id = exclude_fonts[0];
+
+        // Iterate over fonts and check if any of them support the specified char.
+        for face in self.faces() {
+            // Ignore fonts, that were used for shaping already.
+            if exclude_fonts.contains(&face.id) {
+                continue;
+            }
+
+            // Check that the new face has the same style.
+            let base_face = self.face(base_font_id)?;
+            if base_face.style != face.style
+                && base_face.weight != face.weight
+                && base_face.stretch != face.stretch
+            {
+                continue;
+            }
+
+            if !self.has_char(face.id, c) {
+                continue;
+            }
+
+            let base_family = base_face
+                .families
+                .iter()
+                .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                .unwrap_or(&base_face.families[0]);
+
+            let new_family = face
+                .families
+                .iter()
+                .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                .unwrap_or(&base_face.families[0]);
+
+            log::warn!("Fallback from {} to {}.", base_family.0, new_family.0);
+            return self.load_font(face.id);
+        }
+
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FontDBResolvedFont {
+    pub id: ID,
+
+    units_per_em: NonZeroU16,
+
+    // All values below are in font units.
+    ascent: i16,
+    descent: i16,
+    x_height: NonZeroU16,
+
+    underline_position: i16,
+    underline_thickness: NonZeroU16,
+
+    // line-through thickness should be the the same as underline thickness
+    // according to the TrueType spec:
+    // https://docs.microsoft.com/en-us/typography/opentype/spec/os2#ystrikeoutsize
+    line_through_position: i16,
+
+    subscript_offset: i16,
+    superscript_offset: i16,
+}
+
+impl ResolvedFont<ID> for FontDBResolvedFont {
+    fn id(&self) -> ID {
+        self.id
+    }
+
+    fn units_per_em(&self) -> NonZeroU16 {
+        self.units_per_em
+    }
+
+    fn ascent(&self) -> i16 {
+        self.ascent
+    }
+
+    fn descent(&self) -> i16 {
+        self.descent
+    }
+
+    fn x_height(&self) -> NonZeroU16 {
+        self.x_height
+    }
+
+    fn underline_position(&self) -> i16 {
+        self.underline_position
+    }
+
+    fn underline_thickness(&self) -> NonZeroU16 {
+       self.underline_thickness
+    }
+
+    fn line_through_position(&self) -> i16 {
+        self.line_through_position
+    }
+
+    fn subscript_offset(&self) -> i16 {
+        self.subscript_offset
+    }
+
+    fn superscript_offset(&self) -> i16 {
+        self.superscript_offset
+    }
+}
+
+pub(crate) trait DatabaseExt {
+    fn load_font(&self, id: ID) -> Option<FontDBResolvedFont>;
+    fn has_char(&self, id: ID, c: char) -> bool;
+}
+
+impl DatabaseExt for Database {
+    #[inline(never)]
+    fn load_font(&self, id: ID) -> Option<FontDBResolvedFont> {
+        self.with_face_data(id, |data, face_index| -> Option<FontDBResolvedFont> {
+            let font = ttf_parser::Face::parse(data, face_index).ok()?;
+
+            let units_per_em = NonZeroU16::new(font.units_per_em())?;
+
+            let ascent = font.ascender();
+            let descent = font.descender();
+
+            let x_height = font
+                .x_height()
+                .and_then(|x| u16::try_from(x).ok())
+                .and_then(NonZeroU16::new);
+            let x_height = match x_height {
+                Some(height) => height,
+                None => {
+                    // If not set - fallback to height * 45%.
+                    // 45% is what Firefox uses.
+                    u16::try_from((f32::from(ascent - descent) * 0.45) as i32)
+                        .ok()
+                        .and_then(NonZeroU16::new)?
+                }
+            };
+
+            let line_through = font.strikeout_metrics();
+            let line_through_position = match line_through {
+                Some(metrics) => metrics.position,
+                None => x_height.get() as i16 / 2,
+            };
+
+            let (underline_position, underline_thickness) = match font.underline_metrics() {
+                Some(metrics) => {
+                    let thickness = u16::try_from(metrics.thickness)
+                        .ok()
+                        .and_then(NonZeroU16::new)
+                        // `ttf_parser` guarantees that units_per_em is >= 16
+                        .unwrap_or_else(|| NonZeroU16::new(units_per_em.get() / 12).unwrap());
+
+                    (metrics.position, thickness)
+                }
+                None => (
+                    -(units_per_em.get() as i16) / 9,
+                    NonZeroU16::new(units_per_em.get() / 12).unwrap(),
+                ),
+            };
+
+            // 0.2 and 0.4 are generic offsets used by some applications (Inkscape/librsvg).
+            let mut subscript_offset = (units_per_em.get() as f32 / 0.2).round() as i16;
+            let mut superscript_offset = (units_per_em.get() as f32 / 0.4).round() as i16;
+            if let Some(metrics) = font.subscript_metrics() {
+                subscript_offset = metrics.y_offset;
+            }
+
+            if let Some(metrics) = font.superscript_metrics() {
+                superscript_offset = metrics.y_offset;
+            }
+
+            Some(FontDBResolvedFont {
+                id,
+                units_per_em,
+                ascent,
+                descent,
+                x_height,
+                underline_position,
+                underline_thickness,
+                line_through_position,
+                subscript_offset,
+                superscript_offset,
+            })
+        })?
+    }
+
+    #[inline(never)]
+    fn has_char(&self, id: ID, c: char) -> bool {
+        let res = self.with_face_data(id, |font_data, face_index| -> Option<bool> {
+            let font = ttf_parser::Face::parse(font_data, face_index).ok()?;
+            font.glyph_index(c)?;
+            Some(true)
+        });
+
+        res == Some(Some(true))
+    }
+}

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -2,22 +2,22 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::num::NonZeroU16;
-use ::fontdb::ID;
 use crate::{Font, Text};
+use ::fontdb::{Database, ID};
+use std::num::NonZeroU16;
 
 mod flatten;
 
+mod fontdb;
 /// Provides access to the layout of a text node.
 pub mod layout;
-mod fontdb;
 
 /// Convert a text into its paths. This is done in two steps:
 /// 1. We convert the text into glyphs and position them according to the rules specified in the
 /// SVG specifiation. While doing so, we also calculate the text bbox (which is not based on the
 /// outlines of a glyph, but instead the glyph metrics as well as decoration spans).
 /// 2. We convert all of the positioned glyphs into outlines.
-pub(crate) fn convert(text: &mut Text, font_provider: &impl FontProvider) -> Option<()> {
+pub(crate) fn convert(text: &mut Text, font_provider: &dyn FontProvider) -> Option<()> {
     let (text_fragments, bbox) = layout::layout_text(text, font_provider)?;
     text.layouted = text_fragments;
     text.bounding_box = bbox.to_rect();
@@ -32,17 +32,11 @@ pub(crate) fn convert(text: &mut Text, font_provider: &impl FontProvider) -> Opt
 }
 
 pub trait FontProvider {
-    fn with_face_data<P, T>(&self, id: ID, p: P) -> Option<T>
-        where
-            P: FnOnce(&[u8], u32) -> T;
-
     fn resolve_font(&self, font: &Font) -> Option<ResolvedFont>;
 
-    fn find_font_for_char(
-        &self,
-        c: char,
-        exclude_fonts: &[ID],
-    ) -> Option<ResolvedFont>;
+    fn find_font_for_char(&self, c: char, exclude_fonts: &[ID]) -> Option<ResolvedFont>;
+
+    fn fontdb(&self) -> &Database;
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -2,28 +2,57 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::Text;
+use std::num::NonZeroU16;
+use crate::{Font, Text};
 
 mod flatten;
 
 /// Provides access to the layout of a text node.
 pub mod layout;
+mod fontdb;
 
 /// Convert a text into its paths. This is done in two steps:
 /// 1. We convert the text into glyphs and position them according to the rules specified in the
 /// SVG specifiation. While doing so, we also calculate the text bbox (which is not based on the
 /// outlines of a glyph, but instead the glyph metrics as well as decoration spans).
 /// 2. We convert all of the positioned glyphs into outlines.
-pub(crate) fn convert(text: &mut Text, fontdb: &fontdb::Database) -> Option<()> {
-    let (text_fragments, bbox) = layout::layout_text(text, fontdb)?;
+pub(crate) fn convert<T, RF: ResolvedFont<T>>(text: &mut Text, font_provider: &impl FontProvider<T, RF>) -> Option<()> {
+    let (text_fragments, bbox) = layout::layout_text(text, font_provider)?;
     text.layouted = text_fragments;
     text.bounding_box = bbox.to_rect();
     text.abs_bounding_box = bbox.transform(text.abs_transform)?.to_rect();
 
-    let (group, stroke_bbox) = flatten::flatten(text, fontdb)?;
+    let (group, stroke_bbox) = flatten::flatten(text, font_provider)?;
     text.flattened = Box::new(group);
     text.stroke_bounding_box = stroke_bbox.to_rect();
     text.abs_stroke_bounding_box = stroke_bbox.transform(text.abs_transform)?.to_rect();
 
     Some(())
+}
+
+pub trait FontProvider<ID, RF: ResolvedFont<ID>> {
+    fn with_face_data<P, T>(&self, id: ID, p: P) -> Option<T>
+        where
+            P: FnOnce(&[u8], u32) -> T;
+
+    fn resolve_font(&self, font: &Font) -> Option<RF>;
+
+    fn find_font_for_char(
+        &self,
+        c: char,
+        exclude_fonts: &[ID],
+    ) -> Option<RF>;
+}
+
+pub trait ResolvedFont<ID> {
+    fn id(&self) -> ID;
+    fn units_per_em(&self) -> NonZeroU16;
+    fn ascent(&self) -> i16;
+    fn descent(&self) -> i16;
+    fn x_height(&self) -> NonZeroU16;
+    fn underline_position(&self) -> i16;
+    fn underline_thickness(&self) -> NonZeroU16;
+    fn line_through_position(&self) -> i16;
+    fn subscript_offset(&self) -> i16;
+    fn superscript_offset(&self) -> i16;
 }

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::{Font, Text};
 use ::fontdb::{Database, ID};
-use std::num::NonZeroU16;
+
+use crate::{Font, Text};
 
 mod flatten;
-
 mod fontdb;
 /// Provides access to the layout of a text node.
 pub mod layout;
@@ -32,23 +31,9 @@ pub(crate) fn convert(text: &mut Text, font_provider: &dyn FontProvider) -> Opti
 }
 
 pub trait FontProvider {
-    fn resolve_font(&self, font: &Font) -> Option<ResolvedFont>;
+    fn find_font(&self, font: &Font) -> Option<ID>;
 
-    fn find_font_for_char(&self, c: char, exclude_fonts: &[ID]) -> Option<ResolvedFont>;
+    fn find_fallback_font(&self, c: char, base_font_id: ID, used_fonts: &[ID]) -> Option<ID>;
 
     fn fontdb(&self) -> &Database;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct ResolvedFont {
-    pub id: ID,
-    pub units_per_em: NonZeroU16,
-    pub ascent: i16,
-    pub descent: i16,
-    pub x_height: NonZeroU16,
-    pub underline_position: i16,
-    pub underline_thickness: NonZeroU16,
-    pub line_through_position: i16,
-    pub subscript_offset: i16,
-    pub superscript_offset: i16,
 }

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -1,5 +1,5 @@
-use std::ops::Deref;
 use once_cell::sync::Lazy;
+use std::ops::Deref;
 
 static GLOBAL_FONTDB: Lazy<std::sync::Mutex<usvg::fontdb::Database>> = Lazy::new(|| {
     let mut fontdb = usvg::fontdb::Database::new();

--- a/crates/usvg/tests/write.rs
+++ b/crates/usvg/tests/write.rs
@@ -1,3 +1,4 @@
+use std::ops::Deref;
 use once_cell::sync::Lazy;
 
 static GLOBAL_FONTDB: Lazy<std::sync::Mutex<usvg::fontdb::Database>> = Lazy::new(|| {
@@ -29,7 +30,7 @@ fn resave_impl(name: &str, id_prefix: Option<String>, preserve_text: bool) {
     let tree = {
         let fontdb = GLOBAL_FONTDB.lock().unwrap();
         let opt = usvg::Options::default();
-        usvg::Tree::from_str(&input_svg, &opt, &fontdb).unwrap()
+        usvg::Tree::from_str(&input_svg, &opt, fontdb.deref()).unwrap()
     };
     let mut xml_opt = usvg::WriteOptions::default();
     xml_opt.id_prefix = id_prefix;


### PR DESCRIPTION
An attempt to tackle https://github.com/RazrFalcon/resvg/issues/710#issuecomment-2042380784. The basic idea is that we call `resolve_font` and `find_font_for_char` to tell the user which fonts we want (which the user can then dynamically load in the background) and then we request them in the end by requesting a reference to `fontdb` and using that.

In the beginning, I wanted to make the whole thing very generic. Meaning that I tried to write the trait in a way that completely abstracts away from fontdb and fontdb::ID, so that the user has full control over the font selection as well as storing, and it's (in principle) completely abstracted away from usvg. However, there were two big problems with this:
- It turns into a generics hell really quickly, and I think that you would probably not like it.
- I had really big trouble getting it to work with fontdb, based on the fact that (from what I gathered) the only way to get access to the font source is by using the `with_face_data` callback, which makes it really awkward to incorporate it into a trait because it doesn't seem to be possible to create trait objects if there are generics involved.

So for now, this is the best design I was able to come up with, which is far from ideal, but it should be better than nothing. We just need to document it properly.

So the remaining steps would be:
1. Decide whether this design is okay.
2. Once that is done, I will add documentation.
3. Test whether the API fulfills what is needed in Typst.

cc @laurmaedje