### PR TITLE
Support for user-provided font loading callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2894eb653f564384ae8da32b78d9c8db0394715525d917328e435b9babd902"
+checksum = "e32eac81c1135c1df01d4e6d4233c47ba11f6a6d07f33e0bba09d18797077770"
 dependencies = [
  "fontconfig-parser",
  "log",

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -111,7 +111,7 @@ pub extern "C" fn resvg_init_log() {
 /// Also, contains a fonts database used during text to path conversion.
 /// The database is empty by default.
 pub struct resvg_options {
-    options: usvg::Options,
+    options: usvg::Options<'static>,
 }
 
 /// @brief Creates a new #resvg_options object.
@@ -125,7 +125,7 @@ pub extern "C" fn resvg_options_create() -> *mut resvg_options {
 }
 
 #[inline]
-fn cast_opt(opt: *mut resvg_options) -> &'static mut usvg::Options {
+fn cast_opt(opt: *mut resvg_options) -> &'static mut usvg::Options<'static> {
     unsafe {
         assert!(!opt.is_null());
         &mut (*opt).options

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -14,8 +14,6 @@ use std::slice;
 
 use resvg::tiny_skia;
 use resvg::usvg;
-#[cfg(feature = "text")]
-use resvg::usvg::fontdb;
 
 /// @brief List of possible errors.
 #[repr(C)]
@@ -114,8 +112,6 @@ pub extern "C" fn resvg_init_log() {
 /// The database is empty by default.
 pub struct resvg_options {
     options: usvg::Options,
-    #[cfg(feature = "text")]
-    fontdb: fontdb::Database,
 }
 
 /// @brief Creates a new #resvg_options object.
@@ -125,8 +121,6 @@ pub struct resvg_options {
 pub extern "C" fn resvg_options_create() -> *mut resvg_options {
     Box::into_raw(Box::new(resvg_options {
         options: usvg::Options::default(),
-        #[cfg(feature = "text")]
-        fontdb: fontdb::Database::new(),
     }))
 }
 
@@ -135,15 +129,6 @@ fn cast_opt(opt: *mut resvg_options) -> &'static mut usvg::Options {
     unsafe {
         assert!(!opt.is_null());
         &mut (*opt).options
-    }
-}
-
-#[cfg(feature = "text")]
-#[inline]
-fn cast_fontdb(opt: *mut resvg_options) -> &'static mut fontdb::Database {
-    unsafe {
-        assert!(!opt.is_null());
-        &mut (*opt).fontdb
     }
 }
 
@@ -208,7 +193,9 @@ pub extern "C" fn resvg_options_set_font_size(opt: *mut resvg_options, size: f32
 pub extern "C" fn resvg_options_set_serif_family(opt: *mut resvg_options, family: *const c_char) {
     #[cfg(feature = "text")]
     {
-        cast_fontdb(opt).set_serif_family(cstr_to_str(family).unwrap().to_string());
+        cast_opt(opt)
+            .fontdb_mut()
+            .set_serif_family(cstr_to_str(family).unwrap().to_string());
     }
 }
 
@@ -227,7 +214,9 @@ pub extern "C" fn resvg_options_set_sans_serif_family(
 ) {
     #[cfg(feature = "text")]
     {
-        cast_fontdb(opt).set_sans_serif_family(cstr_to_str(family).unwrap().to_string());
+        cast_opt(opt)
+            .fontdb_mut()
+            .set_sans_serif_family(cstr_to_str(family).unwrap().to_string());
     }
 }
 
@@ -243,7 +232,9 @@ pub extern "C" fn resvg_options_set_sans_serif_family(
 pub extern "C" fn resvg_options_set_cursive_family(opt: *mut resvg_options, family: *const c_char) {
     #[cfg(feature = "text")]
     {
-        cast_fontdb(opt).set_cursive_family(cstr_to_str(family).unwrap().to_string());
+        cast_opt(opt)
+            .fontdb_mut()
+            .set_cursive_family(cstr_to_str(family).unwrap().to_string());
     }
 }
 
@@ -259,7 +250,9 @@ pub extern "C" fn resvg_options_set_cursive_family(opt: *mut resvg_options, fami
 pub extern "C" fn resvg_options_set_fantasy_family(opt: *mut resvg_options, family: *const c_char) {
     #[cfg(feature = "text")]
     {
-        cast_fontdb(opt).set_fantasy_family(cstr_to_str(family).unwrap().to_string());
+        cast_opt(opt)
+            .fontdb_mut()
+            .set_fantasy_family(cstr_to_str(family).unwrap().to_string());
     }
 }
 
@@ -278,7 +271,9 @@ pub extern "C" fn resvg_options_set_monospace_family(
 ) {
     #[cfg(feature = "text")]
     {
-        cast_fontdb(opt).set_monospace_family(cstr_to_str(family).unwrap().to_string());
+        cast_opt(opt)
+            .fontdb_mut()
+            .set_monospace_family(cstr_to_str(family).unwrap().to_string());
     }
 }
 
@@ -408,13 +403,7 @@ pub extern "C" fn resvg_options_load_font_data(
     #[cfg(feature = "text")]
     {
         let data = unsafe { slice::from_raw_parts(data as *const u8, len) };
-
-        let opt = unsafe {
-            assert!(!opt.is_null());
-            &mut *opt
-        };
-
-        opt.fontdb.load_font_data(data.to_vec())
+        cast_opt(opt).fontdb_mut().load_font_data(data.to_vec())
     }
 }
 
@@ -438,12 +427,7 @@ pub extern "C" fn resvg_options_load_font_file(
             None => return resvg_error::NOT_AN_UTF8_STR as i32,
         };
 
-        let opt = unsafe {
-            assert!(!opt.is_null());
-            &mut *opt
-        };
-
-        if opt.fontdb.load_font_file(file_path).is_ok() {
+        if cast_opt(opt).fontdb_mut().load_font_file(file_path).is_ok() {
             resvg_error::OK as i32
         } else {
             resvg_error::FILE_OPEN_FAILED as i32
@@ -473,12 +457,7 @@ pub extern "C" fn resvg_options_load_font_file(
 pub extern "C" fn resvg_options_load_system_fonts(opt: *mut resvg_options) {
     #[cfg(feature = "text")]
     {
-        let opt = unsafe {
-            assert!(!opt.is_null());
-            &mut *opt
-        };
-
-        opt.fontdb.load_system_fonts();
+        cast_opt(opt).fontdb_mut().load_system_fonts();
     }
 }
 
@@ -526,12 +505,7 @@ pub extern "C" fn resvg_parse_tree_from_file(
         Err(_) => return resvg_error::FILE_OPEN_FAILED as i32,
     };
 
-    let utree = usvg::Tree::from_data(
-        &file_data,
-        &raw_opt.options,
-        #[cfg(feature = "text")]
-        &raw_opt.fontdb,
-    );
+    let utree = usvg::Tree::from_data(&file_data, &raw_opt.options);
 
     let utree = match utree {
         Ok(tree) => tree,
@@ -569,12 +543,7 @@ pub extern "C" fn resvg_parse_tree_from_data(
         &*opt
     };
 
-    let utree = usvg::Tree::from_data(
-        data,
-        &raw_opt.options,
-        #[cfg(feature = "text")]
-        &raw_opt.fontdb,
-    );
+    let utree = usvg::Tree::from_data(data, &raw_opt.options);
 
     let utree = match utree {
         Ok(tree) => tree,

--- a/crates/resvg/examples/custom_href_resolver.rs
+++ b/crates/resvg/examples/custom_href_resolver.rs
@@ -4,18 +4,14 @@ fn main() {
     let ferris_image = std::sync::Arc::new(std::fs::read("./examples/ferris.png").unwrap());
 
     // We know that our SVG won't have DataUrl hrefs, just return None for such case.
-    let resolve_data = Box::new(
-        |_: &str, _: std::sync::Arc<Vec<u8>>, _: &usvg::Options, _: &usvg::fontdb::Database| None,
-    );
+    let resolve_data = Box::new(|_: &str, _: std::sync::Arc<Vec<u8>>, _: &usvg::Options| None);
 
     // Here we handle xlink:href attribute as string,
     // let's use already loaded Ferris image to match that string.
-    let resolve_string = Box::new(
-        move |href: &str, _: &usvg::Options, _: &usvg::fontdb::Database| match href {
-            "ferris_image" => Some(usvg::ImageKind::PNG(ferris_image.clone())),
-            _ => None,
-        },
-    );
+    let resolve_string = Box::new(move |href: &str, _: &usvg::Options| match href {
+        "ferris_image" => Some(usvg::ImageKind::PNG(ferris_image.clone())),
+        _ => None,
+    });
 
     // Assign new ImageHrefResolver option using our closures.
     opt.image_href_resolver = usvg::ImageHrefResolver {
@@ -23,10 +19,8 @@ fn main() {
         resolve_string,
     };
 
-    let fontdb = usvg::fontdb::Database::new();
-
     let svg_data = std::fs::read("./examples/custom_href_resolver.svg").unwrap();
-    let tree = usvg::Tree::from_data(&svg_data, &opt, &fontdb).unwrap();
+    let tree = usvg::Tree::from_data(&svg_data, &opt).unwrap();
 
     let pixmap_size = tree.size().to_int_size();
     let mut pixmap = tiny_skia::Pixmap::new(pixmap_size.width(), pixmap_size.height()).unwrap();

--- a/crates/resvg/examples/draw_bboxes.rs
+++ b/crates/resvg/examples/draw_bboxes.rs
@@ -1,5 +1,3 @@
-use usvg::fontdb;
-
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if !(args.len() == 3 || args.len() == 5) {
@@ -23,11 +21,10 @@ fn main() {
         .ok()
         .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
-    let mut fontdb = fontdb::Database::new();
-    fontdb.load_system_fonts();
+    opt.fontdb_mut().load_system_fonts();
 
     let svg_data = std::fs::read(&args[1]).unwrap();
-    let tree = usvg::Tree::from_data(&svg_data, &opt, &fontdb).unwrap();
+    let tree = usvg::Tree::from_data(&svg_data, &opt).unwrap();
 
     let mut bboxes = Vec::new();
     let mut stroke_bboxes = Vec::new();

--- a/crates/resvg/examples/minimal.rs
+++ b/crates/resvg/examples/minimal.rs
@@ -1,5 +1,3 @@
-use usvg::fontdb;
-
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     if args.len() != 3 {
@@ -14,11 +12,10 @@ fn main() {
             .ok()
             .and_then(|p| p.parent().map(|p| p.to_path_buf()));
 
-        let mut fontdb = fontdb::Database::new();
-        fontdb.load_system_fonts();
+        opt.fontdb_mut().load_system_fonts();
 
         let svg_data = std::fs::read(&args[1]).unwrap();
-        usvg::Tree::from_data(&svg_data, &opt, &fontdb).unwrap()
+        usvg::Tree::from_data(&svg_data, &opt).unwrap()
     };
 
     let pixmap_size = tree.size().to_int_size();

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -460,7 +460,7 @@ struct Args {
     export_area_drawing: bool,
     perf: bool,
     quiet: bool,
-    usvg: usvg::Options,
+    usvg: usvg::Options<'static>,
     fit_to: FitTo,
     background: Option<svgtypes::Color>,
     raw_args: CliArgs, // TODO: find a better way

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -562,8 +562,8 @@ fn parse_args() -> Result<Args, String> {
         image_rendering: args.image_rendering,
         default_size,
         image_href_resolver: usvg::ImageHrefResolver::default(),
-        fontdb: Arc::new(fontdb::Database::new()),
         font_resolver: usvg::FontResolver::default(),
+        fontdb: Arc::new(fontdb::Database::new()),
     };
 
     Ok(Args {

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -563,6 +563,7 @@ fn parse_args() -> Result<Args, String> {
         default_size,
         image_href_resolver: usvg::ImageHrefResolver::default(),
         fontdb: Arc::new(fontdb::Database::new()),
+        font_resolver: usvg::FontResolver::default(),
     };
 
     Ok(Args {

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 use rgb::{FromSlice, RGBA8};
+use std::process::Command;
 use std::sync::Arc;
 use usvg::fontdb;
 

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -36,7 +36,7 @@ simplecss = "0.2"
 siphasher = "1.0" # perfect hash implementation
 
 # text
-fontdb = { version = "0.17.0", default-features = false, optional = true }
+fontdb = { version = "0.18.0", default-features = false, optional = true }
 rustybuzz = { version = "0.14.0", optional = true }
 unicode-bidi = { version = "0.3", optional = true }
 unicode-script = { version = "0.5", optional = true }

--- a/crates/usvg/src/main.rs
+++ b/crates/usvg/src/main.rs
@@ -416,8 +416,8 @@ fn process(args: Args) -> Result<(), String> {
         default_size: usvg::Size::from_wh(args.default_width as f32, args.default_height as f32)
             .unwrap(),
         image_href_resolver: usvg::ImageHrefResolver::default(),
-        fontdb: Arc::new(fontdb),
         font_resolver: usvg::FontResolver::default(),
+        fontdb: Arc::new(fontdb),
     };
 
     let input_svg = match in_svg {

--- a/crates/usvg/src/main.rs
+++ b/crates/usvg/src/main.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
 use std::process;
+use std::sync::Arc;
 
 use pico_args::Arguments;
 
@@ -415,6 +416,7 @@ fn process(args: Args) -> Result<(), String> {
         default_size: usvg::Size::from_wh(args.default_width as f32, args.default_height as f32)
             .unwrap(),
         image_href_resolver: usvg::ImageHrefResolver::default(),
+        fontdb: Arc::new(fontdb),
     };
 
     let input_svg = match in_svg {
@@ -422,7 +424,7 @@ fn process(args: Args) -> Result<(), String> {
         InputFrom::File(ref path) => std::fs::read(path).map_err(|e| e.to_string()),
     }?;
 
-    let tree = usvg::Tree::from_data(&input_svg, &re_opt, &fontdb).map_err(|e| format!("{}", e))?;
+    let tree = usvg::Tree::from_data(&input_svg, &re_opt).map_err(|e| format!("{}", e))?;
 
     let xml_opt = usvg::WriteOptions {
         id_prefix: args.id_prefix,

--- a/crates/usvg/src/main.rs
+++ b/crates/usvg/src/main.rs
@@ -417,6 +417,7 @@ fn process(args: Args) -> Result<(), String> {
             .unwrap(),
         image_href_resolver: usvg::ImageHrefResolver::default(),
         fontdb: Arc::new(fontdb),
+        font_resolver: usvg::FontResolver::default(),
     };
 
     let input_svg = match in_svg {

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -303,6 +303,8 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
         clip_paths: Vec::new(),
         masks: Vec::new(),
         filters: Vec::new(),
+        #[cfg(feature = "text")]
+        fontdb: opt.fontdb.clone(),
     };
 
     if !svg.is_visible_element(opt) {
@@ -372,6 +374,13 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
     tree.root.collect_masks(&mut tree.masks);
     tree.root.collect_filters(&mut tree.filters);
     tree.root.calculate_bounding_boxes();
+
+    // The fontdb might have been mutated and we want to apply these changes to
+    // the tree's fontdb.
+    #[cfg(feature = "text")]
+    {
+        tree.fontdb = cache.fontdb;
+    }
 
     if restore_viewbox {
         calculate_svg_bbox(&mut tree);

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -30,8 +30,6 @@ pub struct State<'a> {
     /// Width and height can be set independently.
     pub(crate) use_size: (Option<f32>, Option<f32>),
     pub(crate) opt: &'a Options,
-    #[cfg(feature = "text")]
-    pub(crate) fontdb: &'a fontdb::Database,
 }
 
 #[derive(Clone, Default)]
@@ -257,18 +255,9 @@ impl SvgColorExt for svgtypes::Color {
 ///
 /// - If `Document` doesn't have an SVG node - returns an empty tree.
 /// - If `Document` doesn't have a valid size - returns `Error::InvalidSize`.
-pub(crate) fn convert_doc(
-    svg_doc: &svgtree::Document,
-    opt: &Options,
-    #[cfg(feature = "text")] fontdb: &fontdb::Database,
-) -> Result<Tree, Error> {
+pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<Tree, Error> {
     let svg = svg_doc.root_element();
-    let (size, restore_viewbox) = resolve_svg_size(
-        &svg,
-        opt,
-        #[cfg(feature = "text")]
-        fontdb,
-    );
+    let (size, restore_viewbox) = resolve_svg_size(&svg, opt);
     let size = size?;
     let view_box = ViewBox {
         rect: svg
@@ -300,8 +289,6 @@ pub(crate) fn convert_doc(
         view_box: view_box.rect,
         use_size: (None, None),
         opt,
-        #[cfg(feature = "text")]
-        fontdb,
     };
 
     let mut cache = Cache::default();
@@ -362,11 +349,7 @@ pub(crate) fn convert_doc(
     Ok(tree)
 }
 
-fn resolve_svg_size(
-    svg: &SvgNode,
-    opt: &Options,
-    #[cfg(feature = "text")] fontdb: &fontdb::Database,
-) -> (Result<Size, Error>, bool) {
+fn resolve_svg_size(svg: &SvgNode, opt: &Options) -> (Result<Size, Error>, bool) {
     let mut state = State {
         parent_clip_path: None,
         context_element: None,
@@ -375,8 +358,6 @@ fn resolve_svg_size(
         view_box: NonZeroRect::from_xywh(0.0, 0.0, 100.0, 100.0).unwrap(),
         use_size: (None, None),
         opt,
-        #[cfg(feature = "text")]
-        fontdb,
     };
 
     let def = Length::new(100.0, Unit::Percent);

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -30,7 +30,7 @@ pub struct State<'a> {
     /// Used only during nested `svg` size resolving.
     /// Width and height can be set independently.
     pub(crate) use_size: (Option<f32>, Option<f32>),
-    pub(crate) opt: &'a Options,
+    pub(crate) opt: &'a Options<'a>,
 }
 
 #[derive(Clone)]

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -7,6 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::Arc;
 
+#[cfg(feature = "text")]
 use fontdb::Database;
 use svgtypes::{Length, LengthUnit as Unit, PaintOrderKind, TransformOrigin};
 
@@ -37,6 +38,7 @@ pub struct State<'a> {
 pub struct Cache {
     /// This fontdb is initialized from [`Options::fontdb`] and then populated
     /// over the course of conversion.
+    #[cfg(feature = "text")]
     pub fontdb: Arc<Database>,
 
     pub clip_paths: HashMap<String, Arc<ClipPath>>,
@@ -56,8 +58,9 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub(crate) fn new(fontdb: Arc<Database>) -> Self {
+    pub(crate) fn new(#[cfg(feature = "text")] fontdb: Arc<Database>) -> Self {
         Self {
+            #[cfg(feature = "text")]
             fontdb,
 
             clip_paths: HashMap::new(),
@@ -316,7 +319,10 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
         opt,
     };
 
-    let mut cache = Cache::new(opt.fontdb.clone());
+    let mut cache = Cache::new(
+        #[cfg(feature = "text")]
+        opt.fontdb.clone(),
+    );
 
     for node in svg_doc.descendants() {
         if let Some(tag) = node.tag_name() {

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -331,7 +331,11 @@ pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
     sub_opt.text_rendering = opt.text_rendering;
     sub_opt.image_rendering = opt.image_rendering;
     sub_opt.default_size = opt.default_size;
-    sub_opt.fontdb = opt.fontdb.clone();
+
+    #[cfg(feature = "text")]
+    {
+        sub_opt.fontdb = opt.fontdb.clone();
+    }
 
     // The referenced SVG image cannot have any 'image' elements by itself.
     // Not only recursive. Any. Don't know why.

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -14,22 +14,10 @@ use crate::{
 };
 
 /// A shorthand for [ImageHrefResolver]'s data function.
-#[cfg(feature = "text")]
-pub type ImageHrefDataResolverFn =
-    Box<dyn Fn(&str, Arc<Vec<u8>>, &Options, &fontdb::Database) -> Option<ImageKind> + Send + Sync>;
-
-/// A shorthand for [ImageHrefResolver]'s data function.
-#[cfg(not(feature = "text"))]
 pub type ImageHrefDataResolverFn =
     Box<dyn Fn(&str, Arc<Vec<u8>>, &Options) -> Option<ImageKind> + Send + Sync>;
 
 /// A shorthand for [ImageHrefResolver]'s string function.
-#[cfg(feature = "text")]
-pub type ImageHrefStringResolverFn =
-    Box<dyn Fn(&str, &Options, &fontdb::Database) -> Option<ImageKind> + Send + Sync>;
-
-/// A shorthand for [ImageHrefResolver]'s string function.
-#[cfg(not(feature = "text"))]
 pub type ImageHrefStringResolverFn = Box<dyn Fn(&str, &Options) -> Option<ImageKind> + Send + Sync>;
 
 /// An `xlink:href` resolver for `<image>` elements.
@@ -69,29 +57,16 @@ impl ImageHrefResolver {
     /// The actual images would not be decoded. It's up to the renderer.
     pub fn default_data_resolver() -> ImageHrefDataResolverFn {
         Box::new(
-            move |mime: &str,
-                  data: Arc<Vec<u8>>,
-                  opts: &Options,
-                  #[cfg(feature = "text")] fontdb: &fontdb::Database| match mime {
+            move |mime: &str, data: Arc<Vec<u8>>, opts: &Options| match mime {
                 "image/jpg" | "image/jpeg" => Some(ImageKind::JPEG(data)),
                 "image/png" => Some(ImageKind::PNG(data)),
                 "image/gif" => Some(ImageKind::GIF(data)),
-                "image/svg+xml" => load_sub_svg(
-                    &data,
-                    opts,
-                    #[cfg(feature = "text")]
-                    fontdb,
-                ),
+                "image/svg+xml" => load_sub_svg(&data, opts),
                 "text/plain" => match get_image_data_format(&data) {
                     Some(ImageFormat::JPEG) => Some(ImageKind::JPEG(data)),
                     Some(ImageFormat::PNG) => Some(ImageKind::PNG(data)),
                     Some(ImageFormat::GIF) => Some(ImageKind::GIF(data)),
-                    _ => load_sub_svg(
-                        &data,
-                        opts,
-                        #[cfg(feature = "text")]
-                        fontdb,
-                    ),
+                    _ => load_sub_svg(&data, opts),
                 },
                 _ => None,
             },
@@ -106,42 +81,33 @@ impl ImageHrefResolver {
     /// Paths have to be absolute or relative to the input SVG file or relative to
     /// [Options::resources_dir](crate::Options::resources_dir).
     pub fn default_string_resolver() -> ImageHrefStringResolverFn {
-        Box::new(
-            move |href: &str,
-                  opts: &Options,
-                  #[cfg(feature = "text")] fontdb: &fontdb::Database| {
-                let path = opts.get_abs_path(std::path::Path::new(href));
+        Box::new(move |href: &str, opts: &Options| {
+            let path = opts.get_abs_path(std::path::Path::new(href));
 
-                if path.exists() {
-                    let data = match std::fs::read(&path) {
-                        Ok(data) => data,
-                        Err(_) => {
-                            log::warn!("Failed to load '{}'. Skipped.", href);
-                            return None;
-                        }
-                    };
-
-                    match get_image_file_format(&path, &data) {
-                        Some(ImageFormat::JPEG) => Some(ImageKind::JPEG(Arc::new(data))),
-                        Some(ImageFormat::PNG) => Some(ImageKind::PNG(Arc::new(data))),
-                        Some(ImageFormat::GIF) => Some(ImageKind::GIF(Arc::new(data))),
-                        Some(ImageFormat::SVG) => load_sub_svg(
-                            &data,
-                            opts,
-                            #[cfg(feature = "text")]
-                            fontdb,
-                        ),
-                        _ => {
-                            log::warn!("'{}' is not a PNG, JPEG, GIF or SVG(Z) image.", href);
-                            None
-                        }
+            if path.exists() {
+                let data = match std::fs::read(&path) {
+                    Ok(data) => data,
+                    Err(_) => {
+                        log::warn!("Failed to load '{}'. Skipped.", href);
+                        return None;
                     }
-                } else {
-                    log::warn!("'{}' is not a path to an image.", href);
-                    None
+                };
+
+                match get_image_file_format(&path, &data) {
+                    Some(ImageFormat::JPEG) => Some(ImageKind::JPEG(Arc::new(data))),
+                    Some(ImageFormat::PNG) => Some(ImageKind::PNG(Arc::new(data))),
+                    Some(ImageFormat::GIF) => Some(ImageKind::GIF(Arc::new(data))),
+                    Some(ImageFormat::SVG) => load_sub_svg(&data, opts),
+                    _ => {
+                        log::warn!("'{}' is not a PNG, JPEG, GIF or SVG(Z) image.", href);
+                        None
+                    }
                 }
-            },
-        )
+            } else {
+                log::warn!("'{}' is not a path to an image.", href);
+                None
+            }
+        })
     }
 }
 
@@ -323,20 +289,9 @@ pub(crate) fn get_href_data(href: &str, state: &converter::State) -> Option<Imag
             url.mime_type().subtype.as_str()
         );
 
-        (state.opt.image_href_resolver.resolve_data)(
-            &mime,
-            Arc::new(data),
-            state.opt,
-            #[cfg(feature = "text")]
-            state.fontdb,
-        )
+        (state.opt.image_href_resolver.resolve_data)(&mime, Arc::new(data), state.opt)
     } else {
-        (state.opt.image_href_resolver.resolve_string)(
-            href,
-            state.opt,
-            #[cfg(feature = "text")]
-            state.fontdb,
-        )
+        (state.opt.image_href_resolver.resolve_string)(href, state.opt)
     }
 }
 
@@ -365,11 +320,7 @@ fn get_image_data_format(data: &[u8]) -> Option<ImageFormat> {
 ///
 /// Unlike `Tree::from_*` methods, this one will also remove all `image` elements
 /// from the loaded SVG, as required by the spec.
-pub(crate) fn load_sub_svg(
-    data: &[u8],
-    opt: &Options,
-    #[cfg(feature = "text")] fontdb: &fontdb::Database,
-) -> Option<ImageKind> {
+pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
     let mut sub_opt = Options::default();
     sub_opt.resources_dir = None;
     sub_opt.dpi = opt.dpi;
@@ -379,20 +330,16 @@ pub(crate) fn load_sub_svg(
     sub_opt.text_rendering = opt.text_rendering;
     sub_opt.image_rendering = opt.image_rendering;
     sub_opt.default_size = opt.default_size;
+    sub_opt.fontdb = opt.fontdb.clone();
 
     // The referenced SVG image cannot have any 'image' elements by itself.
     // Not only recursive. Any. Don't know why.
     sub_opt.image_href_resolver = ImageHrefResolver {
-        resolve_data: Box::new(|_, _, _, #[cfg(feature = "text")] _| None),
-        resolve_string: Box::new(|_, _, #[cfg(feature = "text")] _| None),
+        resolve_data: Box::new(|_, _, _| None),
+        resolve_string: Box::new(|_, _| None),
     };
 
-    let tree = Tree::from_data(
-        data,
-        &sub_opt,
-        #[cfg(feature = "text")]
-        fontdb,
-    );
+    let tree = Tree::from_data(data, &sub_opt);
     let tree = match tree {
         Ok(tree) => tree,
         Err(_) => {

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -95,37 +95,19 @@ impl crate::Tree {
     /// Parses `Tree` from an SVG data.
     ///
     /// Can contain an SVG string or a gzip compressed data.
-    pub fn from_data(
-        data: &[u8],
-        opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
-    ) -> Result<Self, Error> {
+    pub fn from_data(data: &[u8], opt: &Options) -> Result<Self, Error> {
         if data.starts_with(&[0x1f, 0x8b]) {
             let data = decompress_svgz(data)?;
             let text = std::str::from_utf8(&data).map_err(|_| Error::NotAnUtf8Str)?;
-            Self::from_str(
-                text,
-                opt,
-                #[cfg(feature = "text")]
-                fontdb,
-            )
+            Self::from_str(text, opt)
         } else {
             let text = std::str::from_utf8(data).map_err(|_| Error::NotAnUtf8Str)?;
-            Self::from_str(
-                text,
-                opt,
-                #[cfg(feature = "text")]
-                fontdb,
-            )
+            Self::from_str(text, opt)
         }
     }
 
     /// Parses `Tree` from an SVG string.
-    pub fn from_str(
-        text: &str,
-        opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
-    ) -> Result<Self, Error> {
+    pub fn from_str(text: &str, opt: &Options) -> Result<Self, Error> {
         let xml_opt = roxmltree::ParsingOptions {
             allow_dtd: true,
             ..Default::default()
@@ -134,27 +116,13 @@ impl crate::Tree {
         let doc =
             roxmltree::Document::parse_with_options(text, xml_opt).map_err(Error::ParsingFailed)?;
 
-        Self::from_xmltree(
-            &doc,
-            opt,
-            #[cfg(feature = "text")]
-            fontdb,
-        )
+        Self::from_xmltree(&doc, opt)
     }
 
     /// Parses `Tree` from `roxmltree::Document`.
-    pub fn from_xmltree(
-        doc: &roxmltree::Document,
-        opt: &Options,
-        #[cfg(feature = "text")] fontdb: &fontdb::Database,
-    ) -> Result<Self, Error> {
+    pub fn from_xmltree(doc: &roxmltree::Document, opt: &Options) -> Result<Self, Error> {
         let doc = svgtree::Document::parse_tree(doc)?;
-        self::converter::convert_doc(
-            &doc,
-            opt,
-            #[cfg(feature = "text")]
-            fontdb,
-        )
+        self::converter::convert_doc(&doc, opt)
     }
 }
 

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -87,6 +87,13 @@ pub struct Options<'a> {
     pub font_resolver: FontResolver<'a>,
 
     /// A database of fonts usable by text.
+    ///
+    /// This is a base database. If a custom `font_resolver` is specified,
+    /// additional fonts can be loaded during parsing. Those will be added to a
+    /// copy of this database. The full database containing all fonts referenced
+    /// in a `Tree` becomes available as [`Tree::fontdb`](crate::Tree::fontdb)
+    /// after parsing. If no fonts were loaded dynamically, that database will
+    /// be the same as this one.
     #[cfg(feature = "text")]
     pub fontdb: Arc<fontdb::Database>,
 }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -11,7 +11,7 @@ use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRenderi
 
 /// Processing options.
 #[derive(Debug)]
-pub struct Options {
+pub struct Options<'a> {
     /// Directory that will be used during relative paths resolving.
     ///
     /// Expected to be the same as the directory that contains the SVG file,
@@ -80,19 +80,19 @@ pub struct Options {
     /// Specifies the way `xlink:href` in `<image>` elements should be handled.
     ///
     /// Default: see type's documentation for details
-    pub image_href_resolver: ImageHrefResolver,
+    pub image_href_resolver: ImageHrefResolver<'a>,
 
     /// Specifies how fonts should be resolved and loaded.
     #[cfg(feature = "text")]
-    pub font_resolver: FontResolver,
+    pub font_resolver: FontResolver<'a>,
 
     /// A database of fonts usable by text.
     #[cfg(feature = "text")]
     pub fontdb: Arc<fontdb::Database>,
 }
 
-impl Default for Options {
-    fn default() -> Options {
+impl Default for Options<'_> {
+    fn default() -> Options<'static> {
         Options {
             resources_dir: None,
             dpi: 96.0,
@@ -113,7 +113,7 @@ impl Default for Options {
     }
 }
 
-impl Options {
+impl Options<'_> {
     /// Converts a relative path into absolute relative to the SVG file itself.
     ///
     /// If `Options::resources_dir` is not set, returns itself.

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -5,6 +5,8 @@
 #[cfg(feature = "text")]
 use std::sync::Arc;
 
+#[cfg(feature = "text")]
+use crate::FontResolver;
 use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
 /// Processing options.
@@ -80,6 +82,10 @@ pub struct Options {
     /// Default: see type's documentation for details
     pub image_href_resolver: ImageHrefResolver,
 
+    /// Specifies how fonts should be resolved and loaded.
+    #[cfg(feature = "text")]
+    pub font_resolver: FontResolver,
+
     /// A database of fonts usable by text.
     #[cfg(feature = "text")]
     pub fontdb: Arc<fontdb::Database>,
@@ -99,6 +105,8 @@ impl Default for Options {
             image_rendering: ImageRendering::default(),
             default_size: Size::from_wh(100.0, 100.0).unwrap(),
             image_href_resolver: ImageHrefResolver::default(),
+            #[cfg(feature = "text")]
+            font_resolver: FontResolver::default(),
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
         }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -2,6 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#[cfg(feature = "text")]
+use std::sync::Arc;
+
 use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
 /// Processing options.
@@ -76,6 +79,10 @@ pub struct Options {
     ///
     /// Default: see type's documentation for details
     pub image_href_resolver: ImageHrefResolver,
+
+    /// A database of fonts usable by text.
+    #[cfg(feature = "text")]
+    pub fontdb: Arc<fontdb::Database>,
 }
 
 impl Default for Options {
@@ -92,6 +99,8 @@ impl Default for Options {
             image_rendering: ImageRendering::default(),
             default_size: Size::from_wh(100.0, 100.0).unwrap(),
             image_href_resolver: ImageHrefResolver::default(),
+            #[cfg(feature = "text")]
+            fontdb: Arc::new(fontdb::Database::new()),
         }
     }
 }
@@ -105,5 +114,13 @@ impl Options {
             Some(ref dir) => dir.join(rel_path),
             None => rel_path.into(),
         }
+    }
+
+    /// Mutably acquires the database.
+    ///
+    /// This clones the database if it is currently shared.
+    #[cfg(feature = "text")]
+    pub fn fontdb_mut(&mut self) -> &mut fontdb::Database {
+        Arc::make_mut(&mut self.fontdb)
     }
 }

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -141,7 +141,7 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, &state.opt.fontdb).is_none() {
+    if text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
         return;
     }
 

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -141,7 +141,7 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, state.fontdb).is_none() {
+    if text::convert(&mut text, &state.opt.fontdb).is_none() {
         return;
     }
 

--- a/crates/usvg/src/text/flatten.rs
+++ b/crates/usvg/src/text/flatten.rs
@@ -260,7 +260,7 @@ impl DatabaseExt for Database {
         self.with_face_data(id, |data, face_index| -> Option<Tree> {
             let font = ttf_parser::Face::parse(data, face_index).ok()?;
             let image = font.glyph_svg_image(glyph_id)?;
-            Tree::from_data(image.data, &Options::default(), &fontdb::Database::new()).ok()
+            Tree::from_data(image.data, &Options::default()).ok()
         })?
     }
 
@@ -300,12 +300,7 @@ impl DatabaseExt for Database {
             )?;
             svg.end_element();
 
-            Tree::from_data(
-                &svg.end_document().as_bytes(),
-                &Options::default(),
-                &fontdb::Database::new(),
-            )
-            .ok()
+            Tree::from_data(&svg.end_document().as_bytes(), &Options::default()).ok()
         })?
     }
 }

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -43,7 +43,8 @@ pub struct PositionedGlyph {
     pub id: GlyphId,
     /// The text from the original string that corresponds to that glyph.
     pub text: String,
-    /// The ID of the font the glyph should be taken from.
+    /// The ID of the font the glyph should be taken from. Can be used with the
+    /// [font database of the tree](crate::Tree::fontdb) this glyph is part of.
     pub font: ID,
 }
 

--- a/crates/usvg/src/text/layout.rs
+++ b/crates/usvg/src/text/layout.rs
@@ -154,8 +154,6 @@ impl PositionedGlyph {
 /// visibility.
 #[derive(Clone, Debug)]
 pub struct Span {
-    /// The database which contains the fonts referenced by this span.
-    pub fontdb: Arc<fontdb::Database>,
     /// The fill of the span.
     pub fill: Option<Fill>,
     /// The stroke of the span.
@@ -356,7 +354,6 @@ pub(crate) fn layout_text(
                     .collect();
 
                 spans.push(Span {
-                    fontdb: fontdb.clone(),
                     fill,
                     stroke: span.stroke.clone(),
                     paint_order: span.paint_order,

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -2,7 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use crate::Text;
+use std::sync::Arc;
+
+use fontdb::{Database, ID};
+use svgtypes::FontFamily;
+
+use self::layout::DatabaseExt;
+use crate::{Font, FontStretch, FontStyle, Text};
 
 mod flatten;
 
@@ -10,13 +16,166 @@ mod colr;
 /// Provides access to the layout of a text node.
 pub mod layout;
 
+/// A shorthand for [FontResolver]'s font selection function.
+pub type FontSelectionFn = Box<dyn Fn(&Font, &mut Arc<Database>) -> Option<ID> + Send + Sync>;
+
+/// A shorthand for [FontResolver]'s fallback selection function.
+pub type FallbackSelectionFn =
+    Box<dyn Fn(char, &[ID], &mut Arc<Database>) -> Option<ID> + Send + Sync>;
+
+/// A font resolver for `<text>` elements.
+///
+/// This type can be useful if you want to have an alternative font handling to
+/// the default one. By default, only fonts specified upfront in
+/// [`Options::fontdb`](crate::Options::fontdb) will be used. This type allows
+/// you to load additional fonts on-demand and customize the font selection
+/// process.
+pub struct FontResolver {
+    /// Resolver function that will be used when selecting a specific font
+    /// for a generic [`Font`] specification.
+    pub select_font: FontSelectionFn,
+
+    /// Resolver function that will be used when selecting a fallback font for a
+    /// character.
+    pub select_fallback: FallbackSelectionFn,
+}
+
+impl Default for FontResolver {
+    fn default() -> Self {
+        FontResolver {
+            select_font: FontResolver::default_font_selector(),
+            select_fallback: FontResolver::default_fallback_selector(),
+        }
+    }
+}
+
+impl FontResolver {
+    /// Creates a default font selection resolver.
+    ///
+    /// The default implementation forwards to
+    /// [`query`](fontdb::Database::query) on the font database specified in the
+    /// [`Options`](crate::Options).
+    pub fn default_font_selector() -> FontSelectionFn {
+        Box::new(move |font, fontdb| {
+            let mut name_list = Vec::new();
+            for family in &font.families {
+                name_list.push(match family {
+                    FontFamily::Serif => fontdb::Family::Serif,
+                    FontFamily::SansSerif => fontdb::Family::SansSerif,
+                    FontFamily::Cursive => fontdb::Family::Cursive,
+                    FontFamily::Fantasy => fontdb::Family::Fantasy,
+                    FontFamily::Monospace => fontdb::Family::Monospace,
+                    FontFamily::Named(s) => fontdb::Family::Name(s),
+                });
+            }
+
+            // Use the default font as fallback.
+            name_list.push(fontdb::Family::Serif);
+
+            let stretch = match font.stretch {
+                FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
+                FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
+                FontStretch::Condensed => fontdb::Stretch::Condensed,
+                FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
+                FontStretch::Normal => fontdb::Stretch::Normal,
+                FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
+                FontStretch::Expanded => fontdb::Stretch::Expanded,
+                FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
+                FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
+            };
+
+            let style = match font.style {
+                FontStyle::Normal => fontdb::Style::Normal,
+                FontStyle::Italic => fontdb::Style::Italic,
+                FontStyle::Oblique => fontdb::Style::Oblique,
+            };
+
+            let query = fontdb::Query {
+                families: &name_list,
+                weight: fontdb::Weight(font.weight),
+                stretch,
+                style,
+            };
+
+            let id = fontdb.query(&query);
+            if id.is_none() {
+                log::warn!(
+                    "No match for '{}' font-family.",
+                    font.families
+                        .iter()
+                        .map(|f| f.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+            }
+
+            id
+        })
+    }
+
+    /// Creates a default font fallback selection resolver.
+    pub fn default_fallback_selector() -> FallbackSelectionFn {
+        Box::new(|c, exclude_fonts, fontdb| {
+            let base_font_id = exclude_fonts[0];
+
+            // Iterate over fonts and check if any of them support the specified char.
+            for face in fontdb.faces() {
+                // Ignore fonts, that were used for shaping already.
+                if exclude_fonts.contains(&face.id) {
+                    continue;
+                }
+
+                // Check that the new face has the same style.
+                let base_face = fontdb.face(base_font_id)?;
+                if base_face.style != face.style
+                    && base_face.weight != face.weight
+                    && base_face.stretch != face.stretch
+                {
+                    continue;
+                }
+
+                if !fontdb.has_char(face.id, c) {
+                    continue;
+                }
+
+                let base_family = base_face
+                    .families
+                    .iter()
+                    .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                    .unwrap_or(&base_face.families[0]);
+
+                let new_family = face
+                    .families
+                    .iter()
+                    .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                    .unwrap_or(&base_face.families[0]);
+
+                log::warn!("Fallback from {} to {}.", base_family.0, new_family.0);
+                return Some(face.id);
+            }
+
+            None
+        })
+    }
+}
+
+impl std::fmt::Debug for FontResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("FontResolver { .. }")
+    }
+}
+
 /// Convert a text into its paths. This is done in two steps:
 /// 1. We convert the text into glyphs and position them according to the rules specified in the
 /// SVG specifiation. While doing so, we also calculate the text bbox (which is not based on the
 /// outlines of a glyph, but instead the glyph metrics as well as decoration spans).
 /// 2. We convert all of the positioned glyphs into outlines.
-pub(crate) fn convert(text: &mut Text, fontdb: &fontdb::Database) -> Option<()> {
-    let (text_fragments, bbox) = layout::layout_text(text, fontdb)?;
+pub(crate) fn convert(
+    text: &mut Text,
+    resolver: &FontResolver,
+    fontdb: &mut Arc<fontdb::Database>,
+) -> Option<()> {
+    let (text_fragments, bbox) = layout::layout_text(text, resolver, fontdb)?;
     text.layouted = text_fragments;
     text.bounding_box = bbox.to_rect();
     text.abs_bounding_box = bbox.transform(text.abs_transform)?.to_rect();

--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -1545,6 +1545,8 @@ pub struct Tree {
     pub(crate) clip_paths: Vec<Arc<ClipPath>>,
     pub(crate) masks: Vec<Arc<Mask>>,
     pub(crate) filters: Vec<Arc<filter::Filter>>,
+    #[cfg(feature = "text")]
+    pub(crate) fontdb: Arc<fontdb::Database>,
 }
 
 impl Tree {
@@ -1606,6 +1608,12 @@ impl Tree {
     /// Returns a list of all unique [`Filter`](filter::Filter)s in the tree.
     pub fn filters(&self) -> &[Arc<filter::Filter>] {
         &self.filters
+    }
+
+    /// Returns the font database that applies to all text nodes in the tree.
+    #[cfg(feature = "text")]
+    pub fn fontdb(&self) -> &Arc<fontdb::Database> {
+        &self.fontdb
     }
 
     pub(crate) fn collect_paint_servers(&mut self) {

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -9,8 +9,7 @@ fn clippath_with_invalid_child() {
     </svg>
     ";
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     // clipPath is invalid and should be removed together with rect.
     assert_eq!(tree.root().has_children(), false);
 }
@@ -23,8 +22,7 @@ fn simplify_paths() {
     </svg>
     ";
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     let path = &tree.root().children()[0];
     match path {
         usvg::Node::Path(ref path) => {
@@ -38,8 +36,7 @@ fn simplify_paths() {
 #[test]
 fn size_detection_1() {
     let svg = "<svg viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'/>";
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.size(), usvg::Size::from_wh(10.0, 20.0).unwrap());
 }
 
@@ -47,8 +44,7 @@ fn size_detection_1() {
 fn size_detection_2() {
     let svg =
         "<svg width='30' height='40' viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'/>";
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.size(), usvg::Size::from_wh(30.0, 40.0).unwrap());
 }
 
@@ -56,8 +52,7 @@ fn size_detection_2() {
 fn size_detection_3() {
     let svg =
         "<svg width='50%' height='100%' viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'/>";
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.size(), usvg::Size::from_wh(5.0, 20.0).unwrap());
 }
 
@@ -68,8 +63,7 @@ fn size_detection_4() {
         <circle cx='18' cy='18' r='18'/>
     </svg>
     ";
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.size(), usvg::Size::from_wh(36.0, 36.0).unwrap());
     assert_eq!(tree.size(), usvg::Size::from_wh(36.0, 36.0).unwrap());
 }
@@ -77,16 +71,14 @@ fn size_detection_4() {
 #[test]
 fn size_detection_5() {
     let svg = "<svg xmlns='http://www.w3.org/2000/svg'/>";
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.size(), usvg::Size::from_wh(100.0, 100.0).unwrap());
 }
 
 #[test]
 fn invalid_size_1() {
     let svg = "<svg width='0' height='0' viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'/>";
-    let fontdb = usvg::fontdb::Database::new();
-    let result = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb);
+    let result = usvg::Tree::from_str(&svg, &usvg::Options::default());
     assert!(result.is_err());
 }
 
@@ -104,8 +96,7 @@ fn path_transform() {
     </svg>
     ";
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.root().children().len(), 1);
 
     let group_node = &tree.root().children()[0];
@@ -138,8 +129,7 @@ fn path_transform_nested() {
     </svg>
     ";
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert_eq!(tree.root().children().len(), 1);
 
     let group_node1 = &tree.root().children()[0];
@@ -196,8 +186,7 @@ fn path_transform_in_symbol_no_clip() {
     //     </g>
     // </svg>
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
 
     let group_node1 = &tree.root().children()[0];
     assert!(matches!(group_node1, usvg::Node::Group(_)));
@@ -258,8 +247,7 @@ fn path_transform_in_symbol_with_clip() {
     //     </g>
     // </svg>
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
 
     let group_node1 = &tree.root().children()[0];
     assert!(matches!(group_node1, usvg::Node::Group(_)));
@@ -326,8 +314,7 @@ fn path_transform_in_svg() {
     //     </g>
     // </svg>
 
-    let fontdb = usvg::fontdb::Database::new();
-    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default(), &fontdb).unwrap();
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
 
     let group_node1 = &tree.root().children()[0];
     assert!(matches!(group_node1, usvg::Node::Group(_)));

--- a/tools/explorer-thumbnailer/src/utils.rs
+++ b/tools/explorer-thumbnailer/src/utils.rs
@@ -26,12 +26,10 @@ pub unsafe fn tree_from_istream(pstream: LPSTREAM) -> Result<usvg::Tree, Error> 
     }
     svg_data.set_len(len as usize);
 
-    let opt = usvg::Options::default();
+    let mut opt = usvg::Options::default();
+    opt.fontdb_mut().load_system_fonts();
 
-    let mut fontdb = fontdb::Database::new();
-    fontdb.load_system_fonts();
-
-    let tree = usvg::Tree::from_data(&svg_data, &opt, &fontdb).map_err(|e| Error::TreeError(e))?;
+    let tree = usvg::Tree::from_data(&svg_data, &opt).map_err(|e| Error::TreeError(e))?;
     Ok(tree)
 }
 


### PR DESCRIPTION
This PR adds support for user-provided font loading callbacks. 

Here is small overview of the changes:
- The `Options` now contain an `Arc<Database>` and a new `FontResolver<'a>`. The `fontdb` arguments on other top-level functions were removed.
- The `ImageHrefResolver` is now `ImageHrefResolver<'a>` (since it might as well). With the default resolvers, you just get `Options<'static>`.
- The resolver functions take `&mut Arc<Database>`, so they can mutate the database with `Arc::make_mut` if necessary, but if they don't need to add a font, we don't force the database to be cloned.
- For each tree conversion, we have an `Arc<Database>` in the `Cache`, which is populated over the course of conversion. It is only cloned if fonts are actually added.
- The database from the `Cache` is moved into the `Tree` after conversion and users can access it with `tree.fontdb()` to make sense of the `ID`s in their `Span`s.
- Sub-SVGs start with a fresh database from the `Options`, but share the same resolver.
- The database in the `Options` is never mutated (it's `&Options` after all)

One small change in `fontdb` is necessary to make writing a custom `FontResolver` possible, or at least convenient: The best function to add a new font is `push_face_info`, but it doesn't return the new `ID` it assigned. I've opened https://github.com/RazrFalcon/fontdb/pull/66 to change that. As it is a breaking change, resvg would need to update to a new release of fontdb. (Alternatively, we could make it non-breaking with a new function.)

Supersedes https://github.com/RazrFalcon/resvg/pull/754