### PR TITLE
Make FontResolver a trait and use to provide access to a fontdb

### DIFF
--- a/crates/resvg/examples/draw_bboxes.rs
+++ b/crates/resvg/examples/draw_bboxes.rs
@@ -15,13 +15,14 @@ fn main() {
         1.0
     };
 
+    let font_resolver = usvg::DefaultFontResolver::with_system_fonts();
+
     let mut opt = usvg::Options::default();
     // Get file's absolute directory.
     opt.resources_dir = std::fs::canonicalize(&args[1])
         .ok()
         .and_then(|p| p.parent().map(|p| p.to_path_buf()));
-
-    opt.fontdb_mut().load_system_fonts();
+    opt.font_resolver = Some(&font_resolver);
 
     let svg_data = std::fs::read(&args[1]).unwrap();
     let tree = usvg::Tree::from_data(&svg_data, &opt).unwrap();

--- a/crates/resvg/examples/minimal.rs
+++ b/crates/resvg/examples/minimal.rs
@@ -6,13 +6,14 @@ fn main() {
     }
 
     let tree = {
+        let font_resolver = usvg::DefaultFontResolver::with_system_fonts();
+
         let mut opt = usvg::Options::default();
         // Get file's absolute directory.
         opt.resources_dir = std::fs::canonicalize(&args[1])
             .ok()
             .and_then(|p| p.parent().map(|p| p.to_path_buf()));
-
-        opt.fontdb_mut().load_system_fonts();
+        opt.font_resolver = Some(&font_resolver);
 
         let svg_data = std::fs::read(&args[1]).unwrap();
         usvg::Tree::from_data(&svg_data, &opt).unwrap()

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -562,7 +562,7 @@ fn parse_args() -> Result<Args, String> {
         image_rendering: args.image_rendering,
         default_size,
         image_href_resolver: usvg::ImageHrefResolver::default(),
-        font_resolver: usvg::FontResolver::default(),
+        font_resolver: Some(usvg::FontResolver::default()),
         fontdb: Arc::new(fontdb::Database::new()),
     };
 

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -562,7 +562,7 @@ fn parse_args() -> Result<Args, String> {
         image_rendering: args.image_rendering,
         default_size,
         image_href_resolver: usvg::ImageHrefResolver::default(),
-        font_resolver: Some(usvg::FontResolver::default()),
+        font_resolver: Some(&usvg::DefaultFontResolver),
         fontdb: Arc::new(fontdb::Database::new()),
     };
 

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -1,7 +1,7 @@
 use once_cell::sync::Lazy;
 use rgb::{FromSlice, RGBA8};
 use std::sync::Arc;
-use usvg::fontdb;
+use usvg::{fontdb, DefaultFontResolver};
 
 #[rustfmt::skip]
 mod render;
@@ -36,6 +36,7 @@ pub fn render(name: &str) -> usize {
             .unwrap()
             .to_owned(),
     );
+    opt.font_resolver = Some(&DefaultFontResolver);
     opt.fontdb = GLOBAL_FONTDB.clone();
 
     let tree = {

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -1,6 +1,5 @@
 use once_cell::sync::Lazy;
 use rgb::{FromSlice, RGBA8};
-use std::sync::Arc;
 use usvg::{fontdb, DefaultFontResolver};
 
 #[rustfmt::skip]
@@ -10,7 +9,7 @@ mod extra;
 
 const IMAGE_SIZE: u32 = 300;
 
-static GLOBAL_FONTDB: Lazy<Arc<fontdb::Database>> = Lazy::new(|| {
+static GLOBAL_FONTDB: Lazy<fontdb::Database> = Lazy::new(|| {
     if let Ok(()) = log::set_logger(&LOGGER) {
         log::set_max_level(log::LevelFilter::Warn);
     }
@@ -22,12 +21,14 @@ static GLOBAL_FONTDB: Lazy<Arc<fontdb::Database>> = Lazy::new(|| {
     fontdb.set_cursive_family("Yellowtail");
     fontdb.set_fantasy_family("Sedgwick Ave Display");
     fontdb.set_monospace_family("Noto Mono");
-    Arc::new(fontdb)
+    fontdb
 });
 
 pub fn render(name: &str) -> usize {
     let svg_path = format!("tests/{}.svg", name);
     let png_path = format!("tests/{}.png", name);
+
+    let font_resolver = DefaultFontResolver::new(GLOBAL_FONTDB.clone());
 
     let mut opt = usvg::Options::default();
     opt.resources_dir = Some(
@@ -36,8 +37,7 @@ pub fn render(name: &str) -> usize {
             .unwrap()
             .to_owned(),
     );
-    opt.font_resolver = Some(&DefaultFontResolver);
-    opt.fontdb = GLOBAL_FONTDB.clone();
+    opt.font_resolver = Some(&font_resolver);
 
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();
@@ -91,8 +91,9 @@ pub fn render_extra_with_scale(name: &str, scale: f32) -> usize {
     let svg_path = format!("tests/{}.svg", name);
     let png_path = format!("tests/{}.png", name);
 
+    let font_resolver = DefaultFontResolver::new(GLOBAL_FONTDB.clone());
     let mut opt = usvg::Options::default();
-    opt.fontdb = GLOBAL_FONTDB.clone();
+    opt.font_resolver = Some(&font_resolver);
 
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();
@@ -141,8 +142,9 @@ pub fn render_node(name: &str, id: &str) -> usize {
     let svg_path = format!("tests/{}.svg", name);
     let png_path = format!("tests/{}.png", name);
 
+    let font_resolver = DefaultFontResolver::new(GLOBAL_FONTDB.clone());
     let mut opt = usvg::Options::default();
-    opt.fontdb = GLOBAL_FONTDB.clone();
+    opt.font_resolver = Some(&font_resolver);
 
     let tree = {
         let svg_data = std::fs::read(&svg_path).unwrap();

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -7,8 +7,6 @@ use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 use std::sync::Arc;
 
-#[cfg(feature = "text")]
-use fontdb::Database;
 use svgtypes::{Length, LengthUnit as Unit, PaintOrderKind, TransformOrigin};
 
 use super::svgtree::{self, AId, EId, FromValue, SvgNode};
@@ -36,11 +34,6 @@ pub struct State<'a> {
 
 #[derive(Clone)]
 pub struct Cache {
-    /// This fontdb is initialized from [`Options::fontdb`] and then populated
-    /// over the course of conversion.
-    #[cfg(feature = "text")]
-    pub fontdb: Arc<Database>,
-
     pub clip_paths: HashMap<String, Arc<ClipPath>>,
     pub masks: HashMap<String, Arc<Mask>>,
     pub filters: HashMap<String, Arc<filter::Filter>>,
@@ -58,11 +51,8 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub(crate) fn new(#[cfg(feature = "text")] fontdb: Arc<Database>) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            #[cfg(feature = "text")]
-            fontdb,
-
             clip_paths: HashMap::new(),
             masks: HashMap::new(),
             filters: HashMap::new(),
@@ -319,10 +309,7 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
         opt,
     };
 
-    let mut cache = Cache::new(
-        #[cfg(feature = "text")]
-        opt.fontdb.clone(),
-    );
+    let mut cache = Cache::new();
 
     for node in svg_doc.descendants() {
         if let Some(tag) = node.tag_name() {

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -303,8 +303,6 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
         clip_paths: Vec::new(),
         masks: Vec::new(),
         filters: Vec::new(),
-        #[cfg(feature = "text")]
-        fontdb: opt.fontdb.clone(),
     };
 
     if !svg.is_visible_element(opt) {
@@ -374,13 +372,6 @@ pub(crate) fn convert_doc(svg_doc: &svgtree::Document, opt: &Options) -> Result<
     tree.root.collect_masks(&mut tree.masks);
     tree.root.collect_filters(&mut tree.filters);
     tree.root.calculate_bounding_boxes();
-
-    // The fontdb might have been mutated and we want to apply these changes to
-    // the tree's fontdb.
-    #[cfg(feature = "text")]
-    {
-        tree.fontdb = cache.fontdb;
-    }
 
     if restore_viewbox {
         calculate_svg_bbox(&mut tree);

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -345,7 +345,6 @@ pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
     {
         // In the referenced SVG, we start with the unmodified user-provided
         // fontdb, not the one from the cache.
-        sub_opt.fontdb = opt.fontdb.clone();
         sub_opt.font_resolver = opt.font_resolver;
     }
 

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -348,12 +348,15 @@ pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
         sub_opt.fontdb = opt.fontdb.clone();
 
         // Can't clone the resolver, so we create a new one that forwards to it.
-        sub_opt.font_resolver = crate::FontResolver {
-            select_font: Box::new(|font, db| (opt.font_resolver.select_font)(font, db)),
-            select_fallback: Box::new(|c, used_fonts, db| {
-                (opt.font_resolver.select_fallback)(c, used_fonts, db)
-            }),
-        };
+        sub_opt.font_resolver = opt
+            .font_resolver
+            .as_ref()
+            .map(|resolver| crate::FontResolver {
+                select_font: Box::new(|font, db| (resolver.select_font)(font, db)),
+                select_fallback: Box::new(|c, used_fonts, db| {
+                    (resolver.select_fallback)(c, used_fonts, db)
+                }),
+            });
     }
 
     let tree = Tree::from_data(data, &sub_opt);

--- a/crates/usvg/src/parser/image.rs
+++ b/crates/usvg/src/parser/image.rs
@@ -346,17 +346,7 @@ pub(crate) fn load_sub_svg(data: &[u8], opt: &Options) -> Option<ImageKind> {
         // In the referenced SVG, we start with the unmodified user-provided
         // fontdb, not the one from the cache.
         sub_opt.fontdb = opt.fontdb.clone();
-
-        // Can't clone the resolver, so we create a new one that forwards to it.
-        sub_opt.font_resolver = opt
-            .font_resolver
-            .as_ref()
-            .map(|resolver| crate::FontResolver {
-                select_font: Box::new(|font, db| (resolver.select_font)(font, db)),
-                select_fallback: Box::new(|c, used_fonts, db| {
-                    (resolver.select_fallback)(c, used_fonts, db)
-                }),
-            });
+        sub_opt.font_resolver = opt.font_resolver;
     }
 
     let tree = Tree::from_data(data, &sub_opt);

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -7,7 +7,9 @@ use std::sync::Arc;
 
 #[cfg(feature = "text")]
 use crate::FontResolver;
-use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
+use crate::{
+    DefaultFontResolver, ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering,
+};
 
 /// Processing options.
 #[derive(Debug)]
@@ -84,7 +86,7 @@ pub struct Options<'a> {
 
     /// Specifies how fonts should be resolved and loaded.
     #[cfg(feature = "text")]
-    pub font_resolver: Option<FontResolver<'a>>,
+    pub font_resolver: Option<&'a dyn FontResolver>,
 
     /// A database of fonts usable by text.
     ///
@@ -113,7 +115,7 @@ impl Default for Options<'_> {
             default_size: Size::from_wh(100.0, 100.0).unwrap(),
             image_href_resolver: ImageHrefResolver::default(),
             #[cfg(feature = "text")]
-            font_resolver: None,
+            font_resolver: Some(&DefaultFontResolver),
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
         }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -3,9 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #[cfg(feature = "text")]
-use std::sync::Arc;
-
-#[cfg(feature = "text")]
 use crate::FontResolver;
 use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
@@ -82,24 +79,13 @@ pub struct Options<'a> {
     /// Default: see type's documentation for details
     pub image_href_resolver: ImageHrefResolver<'a>,
 
-    /// Specifies how fonts should be resolved and loaded.
+    /// Provides access to the [`fontdb::Database`] and resolves font properties into fonts
     ///
     /// By default this is `None`. To successfully process text in SVGs, use
     /// [`DefaultFontResolver`](crate::DefaultFontResolver) or a custom
     /// [`FontResolver`].
     #[cfg(feature = "text")]
     pub font_resolver: Option<&'a dyn FontResolver>,
-
-    /// A database of fonts usable by text.
-    ///
-    /// This is a base database. If a custom `font_resolver` is specified,
-    /// additional fonts can be loaded during parsing. Those will be added to a
-    /// copy of this database. The full database containing all fonts referenced
-    /// in a `Tree` becomes available as [`Tree::fontdb`](crate::Tree::fontdb)
-    /// after parsing. If no fonts were loaded dynamically, that database will
-    /// be the same as this one.
-    #[cfg(feature = "text")]
-    pub fontdb: Arc<fontdb::Database>,
 }
 
 impl Default for Options<'_> {
@@ -118,8 +104,6 @@ impl Default for Options<'_> {
             image_href_resolver: ImageHrefResolver::default(),
             #[cfg(feature = "text")]
             font_resolver: None,
-            #[cfg(feature = "text")]
-            fontdb: Arc::new(fontdb::Database::new()),
         }
     }
 }
@@ -133,13 +117,5 @@ impl Options<'_> {
             Some(ref dir) => dir.join(rel_path),
             None => rel_path.into(),
         }
-    }
-
-    /// Mutably acquires the database.
-    ///
-    /// This clones the database if it is currently shared.
-    #[cfg(feature = "text")]
-    pub fn fontdb_mut(&mut self) -> &mut fontdb::Database {
-        Arc::make_mut(&mut self.fontdb)
     }
 }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -84,7 +84,7 @@ pub struct Options<'a> {
 
     /// Specifies how fonts should be resolved and loaded.
     #[cfg(feature = "text")]
-    pub font_resolver: FontResolver<'a>,
+    pub font_resolver: Option<FontResolver<'a>>,
 
     /// A database of fonts usable by text.
     ///
@@ -113,7 +113,7 @@ impl Default for Options<'_> {
             default_size: Size::from_wh(100.0, 100.0).unwrap(),
             image_href_resolver: ImageHrefResolver::default(),
             #[cfg(feature = "text")]
-            font_resolver: FontResolver::default(),
+            font_resolver: None,
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
         }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -7,9 +7,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "text")]
 use crate::FontResolver;
-use crate::{
-    DefaultFontResolver, ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering,
-};
+use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
 /// Processing options.
 #[derive(Debug)]
@@ -85,6 +83,10 @@ pub struct Options<'a> {
     pub image_href_resolver: ImageHrefResolver<'a>,
 
     /// Specifies how fonts should be resolved and loaded.
+    ///
+    /// By default this is `None`. To successfully process text in SVGs, use
+    /// [`DefaultFontResolver`](crate::DefaultFontResolver) or a custom
+    /// [`FontResolver`].
     #[cfg(feature = "text")]
     pub font_resolver: Option<&'a dyn FontResolver>,
 
@@ -115,7 +117,7 @@ impl Default for Options<'_> {
             default_size: Size::from_wh(100.0, 100.0).unwrap(),
             image_href_resolver: ImageHrefResolver::default(),
             #[cfg(feature = "text")]
-            font_resolver: Some(&DefaultFontResolver),
+            font_resolver: None,
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
         }

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -142,7 +142,7 @@ pub(crate) fn convert(
     };
 
     if let Some(ref font_resolver) = state.opt.font_resolver {
-        if text::convert(&mut text, *font_resolver, &mut cache.fontdb).is_none() {
+        if text::convert(&mut text, *font_resolver).is_none() {
             return;
         }
 

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -141,11 +141,13 @@ pub(crate) fn convert(
         layouted: vec![],
     };
 
-    if text::convert(&mut text, &state.opt.font_resolver, &mut cache.fontdb).is_none() {
-        return;
-    }
+    if let Some(ref font_resolver) = state.opt.font_resolver {
+        if text::convert(&mut text, font_resolver, &mut cache.fontdb).is_none() {
+            return;
+        }
 
-    parent.children.push(Node::Text(Box::new(text)));
+        parent.children.push(Node::Text(Box::new(text)));
+    }
 }
 
 struct IterState {

--- a/crates/usvg/src/parser/text.rs
+++ b/crates/usvg/src/parser/text.rs
@@ -142,7 +142,7 @@ pub(crate) fn convert(
     };
 
     if let Some(ref font_resolver) = state.opt.font_resolver {
-        if text::convert(&mut text, font_resolver, &mut cache.fontdb).is_none() {
+        if text::convert(&mut text, *font_resolver, &mut cache.fontdb).is_none() {
             return;
         }
 

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use fontdb::{Database, ID};
@@ -16,41 +17,6 @@ mod colr;
 /// Provides access to the layout of a text node.
 pub mod layout;
 
-/// A shorthand for [FontResolver]'s font selection function.
-///
-/// This function receives a font specification (families + a style, weight,
-/// stretch triple) and a font database and should return the ID of the font
-/// that shall be used (if any).
-///
-/// In the basic case, the function will search the existing fonts in the
-/// database to find a good match, e.g. via
-/// [`Database::query`](fontdb::Database::query). This is what the [default
-/// implementation](FontResolver::default_font_selector) does.
-///
-/// Users with more complex requirements can mutate the database to load
-/// additional fonts dynamically. To perform mutation, it is recommended to call
-/// `Arc::make_mut` on the provided database. (This call is not done outside of
-/// the callback to not needless clone an underlying shared database if no
-/// mutation will be performed.) It is important that the database is only
-/// mutated additively. Removing fonts or replacing the entire database will
-/// break things.
-pub type FontSelectionFn<'a> =
-    Box<dyn Fn(&Font, &mut Arc<Database>) -> Option<ID> + Send + Sync + 'a>;
-
-/// A shorthand for [FontResolver]'s fallback selection function.
-///
-/// This function receives a specific character, a list of already used fonts,
-/// and a font database. It should return the ID of a font that
-/// - is not any of the already used fonts
-/// - is as close as possible to the first already used font (if any)
-/// - supports the given character
-///
-/// The function can search the existing database, but can also load additional
-/// fonts dynamically. See the documentation of [`FontSelectionFn`] for more
-/// details.
-pub type FallbackSelectionFn<'a> =
-    Box<dyn Fn(char, &[ID], &mut Arc<Database>) -> Option<ID> + Send + Sync + 'a>;
-
 /// A font resolver for `<text>` elements.
 ///
 /// This type can be useful if you want to have an alternative font handling to
@@ -58,141 +24,160 @@ pub type FallbackSelectionFn<'a> =
 /// [`Options::fontdb`](crate::Options::fontdb) will be used. This type allows
 /// you to load additional fonts on-demand and customize the font selection
 /// process.
-pub struct FontResolver<'a> {
+pub trait FontResolver: Debug + Sync {
     /// Resolver function that will be used when selecting a specific font
     /// for a generic [`Font`] specification.
-    pub select_font: FontSelectionFn<'a>,
+    ///
+    /// This function receives a font specification (families + a style, weight,
+    /// stretch triple) and a font database and should return the ID of the font
+    /// that shall be used (if any).
+    ///
+    /// In the basic case, the function will search the existing fonts in the
+    /// database to find a good match, e.g. via
+    /// [`Database::query`](fontdb::Database::query). This is what the [default
+    /// implementation](FontResolver::default_font_selector) does.
+    ///
+    /// Users with more complex requirements can mutate the database to load
+    /// additional fonts dynamically. To perform mutation, it is recommended to call
+    /// `Arc::make_mut` on the provided database. (This call is not done outside of
+    /// the callback to not needless clone an underlying shared database if no
+    /// mutation will be performed.) It is important that the database is only
+    /// mutated additively. Removing fonts or replacing the entire database will
+    /// break things.
+    fn select_font(&self, font: &Font, fontdb: &mut Arc<Database>) -> Option<ID>;
 
     /// Resolver function that will be used when selecting a fallback font for a
     /// character.
-    pub select_fallback: FallbackSelectionFn<'a>,
+    ///
+    /// This function receives a specific character, a list of already used fonts,
+    /// and a font database. It should return the ID of a font that
+    /// - is not any of the already used fonts
+    /// - is as close as possible to the first already used font (if any)
+    /// - supports the given character
+    ///
+    /// The function can search the existing database, but can also load additional
+    /// fonts dynamically. See the documentation of [`FontSelectionFn`] for more
+    /// details.
+    fn select_fallback(
+        &self,
+        c: char,
+        exclude_fonts: &[ID],
+        fontdb: &mut Arc<Database>,
+    ) -> Option<ID>;
 }
 
-impl Default for FontResolver<'_> {
-    fn default() -> Self {
-        FontResolver {
-            select_font: FontResolver::default_font_selector(),
-            select_fallback: FontResolver::default_fallback_selector(),
+/// Default font resolver
+///
+/// The default font selector forwards to
+/// [`query`](fontdb::Database::query) on the font database specified in the
+/// [`Options`](crate::Options).
+///
+/// The default fallback selector searches through the entire `fontdb`
+/// to find a font that has the correct style and supports the character.
+#[derive(Clone, Copy, Debug)]
+pub struct DefaultFontResolver;
+impl FontResolver for DefaultFontResolver {
+    fn select_font(&self, font: &Font, fontdb: &mut Arc<Database>) -> Option<ID> {
+        let mut name_list = Vec::new();
+        for family in &font.families {
+            name_list.push(match family {
+                FontFamily::Serif => fontdb::Family::Serif,
+                FontFamily::SansSerif => fontdb::Family::SansSerif,
+                FontFamily::Cursive => fontdb::Family::Cursive,
+                FontFamily::Fantasy => fontdb::Family::Fantasy,
+                FontFamily::Monospace => fontdb::Family::Monospace,
+                FontFamily::Named(s) => fontdb::Family::Name(s),
+            });
         }
-    }
-}
 
-impl FontResolver<'_> {
-    /// Creates a default font selection resolver.
-    ///
-    /// The default implementation forwards to
-    /// [`query`](fontdb::Database::query) on the font database specified in the
-    /// [`Options`](crate::Options).
-    pub fn default_font_selector() -> FontSelectionFn<'static> {
-        Box::new(move |font, fontdb| {
-            let mut name_list = Vec::new();
-            for family in &font.families {
-                name_list.push(match family {
-                    FontFamily::Serif => fontdb::Family::Serif,
-                    FontFamily::SansSerif => fontdb::Family::SansSerif,
-                    FontFamily::Cursive => fontdb::Family::Cursive,
-                    FontFamily::Fantasy => fontdb::Family::Fantasy,
-                    FontFamily::Monospace => fontdb::Family::Monospace,
-                    FontFamily::Named(s) => fontdb::Family::Name(s),
-                });
-            }
+        // Use the default font as fallback.
+        name_list.push(fontdb::Family::Serif);
 
-            // Use the default font as fallback.
-            name_list.push(fontdb::Family::Serif);
+        let stretch = match font.stretch {
+            FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
+            FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
+            FontStretch::Condensed => fontdb::Stretch::Condensed,
+            FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
+            FontStretch::Normal => fontdb::Stretch::Normal,
+            FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
+            FontStretch::Expanded => fontdb::Stretch::Expanded,
+            FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
+            FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
+        };
 
-            let stretch = match font.stretch {
-                FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
-                FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
-                FontStretch::Condensed => fontdb::Stretch::Condensed,
-                FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
-                FontStretch::Normal => fontdb::Stretch::Normal,
-                FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
-                FontStretch::Expanded => fontdb::Stretch::Expanded,
-                FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
-                FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
-            };
+        let style = match font.style {
+            FontStyle::Normal => fontdb::Style::Normal,
+            FontStyle::Italic => fontdb::Style::Italic,
+            FontStyle::Oblique => fontdb::Style::Oblique,
+        };
 
-            let style = match font.style {
-                FontStyle::Normal => fontdb::Style::Normal,
-                FontStyle::Italic => fontdb::Style::Italic,
-                FontStyle::Oblique => fontdb::Style::Oblique,
-            };
+        let query = fontdb::Query {
+            families: &name_list,
+            weight: fontdb::Weight(font.weight),
+            stretch,
+            style,
+        };
 
-            let query = fontdb::Query {
-                families: &name_list,
-                weight: fontdb::Weight(font.weight),
-                stretch,
-                style,
-            };
-
-            let id = fontdb.query(&query);
-            if id.is_none() {
-                log::warn!(
-                    "No match for '{}' font-family.",
-                    font.families
-                        .iter()
-                        .map(|f| f.to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
-            }
-
-            id
-        })
-    }
-
-    /// Creates a default font fallback selection resolver.
-    ///
-    /// The default implementation searches through the entire `fontdb`
-    /// to find a font that has the correct style and supports the character.
-    pub fn default_fallback_selector() -> FallbackSelectionFn<'static> {
-        Box::new(|c, exclude_fonts, fontdb| {
-            let base_font_id = exclude_fonts[0];
-
-            // Iterate over fonts and check if any of them support the specified char.
-            for face in fontdb.faces() {
-                // Ignore fonts, that were used for shaping already.
-                if exclude_fonts.contains(&face.id) {
-                    continue;
-                }
-
-                // Check that the new face has the same style.
-                let base_face = fontdb.face(base_font_id)?;
-                if base_face.style != face.style
-                    && base_face.weight != face.weight
-                    && base_face.stretch != face.stretch
-                {
-                    continue;
-                }
-
-                if !fontdb.has_char(face.id, c) {
-                    continue;
-                }
-
-                let base_family = base_face
-                    .families
+        let id = fontdb.query(&query);
+        if id.is_none() {
+            log::warn!(
+                "No match for '{}' font-family.",
+                font.families
                     .iter()
-                    .find(|f| f.1 == fontdb::Language::English_UnitedStates)
-                    .unwrap_or(&base_face.families[0]);
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
 
-                let new_family = face
-                    .families
-                    .iter()
-                    .find(|f| f.1 == fontdb::Language::English_UnitedStates)
-                    .unwrap_or(&base_face.families[0]);
+        id
+    }
 
-                log::warn!("Fallback from {} to {}.", base_family.0, new_family.0);
-                return Some(face.id);
+    fn select_fallback(
+        &self,
+        c: char,
+        exclude_fonts: &[ID],
+        fontdb: &mut Arc<Database>,
+    ) -> Option<ID> {
+        let base_font_id = exclude_fonts[0];
+
+        // Iterate over fonts and check if any of them support the specified char.
+        for face in fontdb.faces() {
+            // Ignore fonts, that were used for shaping already.
+            if exclude_fonts.contains(&face.id) {
+                continue;
             }
 
-            None
-        })
-    }
-}
+            // Check that the new face has the same style.
+            let base_face = fontdb.face(base_font_id)?;
+            if base_face.style != face.style
+                && base_face.weight != face.weight
+                && base_face.stretch != face.stretch
+            {
+                continue;
+            }
 
-impl std::fmt::Debug for FontResolver<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("FontResolver { .. }")
+            if !fontdb.has_char(face.id, c) {
+                continue;
+            }
+
+            let base_family = base_face
+                .families
+                .iter()
+                .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                .unwrap_or(&base_face.families[0]);
+
+            let new_family = face
+                .families
+                .iter()
+                .find(|f| f.1 == fontdb::Language::English_UnitedStates)
+                .unwrap_or(&base_face.families[0]);
+
+            log::warn!("Fallback from {} to {}.", base_family.0, new_family.0);
+            return Some(face.id);
+        }
+
+        None
     }
 }
 
@@ -203,7 +188,7 @@ impl std::fmt::Debug for FontResolver<'_> {
 /// 2. We convert all of the positioned glyphs into outlines.
 pub(crate) fn convert(
     text: &mut Text,
-    resolver: &FontResolver,
+    resolver: &dyn FontResolver,
     fontdb: &mut Arc<fontdb::Database>,
 ) -> Option<()> {
     let (text_fragments, bbox) = layout::layout_text(text, resolver, fontdb)?;

--- a/crates/usvg/src/text/mod.rs
+++ b/crates/usvg/src/text/mod.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use std::fmt::Debug;
-use std::sync::Arc;
 
 use fontdb::{Database, ID};
 use svgtypes::FontFamily;
@@ -25,6 +24,9 @@ pub mod layout;
 /// you to load additional fonts on-demand and customize the font selection
 /// process.
 pub trait FontResolver: Debug + Sync {
+    /// Provide access to the font [`Database`]
+    fn fontdb(&self) -> &Database;
+
     /// Resolver function that will be used when selecting a specific font
     /// for a generic [`Font`] specification.
     ///
@@ -44,7 +46,7 @@ pub trait FontResolver: Debug + Sync {
     /// mutation will be performed.) It is important that the database is only
     /// mutated additively. Removing fonts or replacing the entire database will
     /// break things.
-    fn select_font(&self, font: &Font, fontdb: &mut Arc<Database>) -> Option<ID>;
+    fn select_font(&self, font: &Font) -> Option<ID>;
 
     /// Resolver function that will be used when selecting a fallback font for a
     /// character.
@@ -58,12 +60,7 @@ pub trait FontResolver: Debug + Sync {
     /// The function can search the existing database, but can also load additional
     /// fonts dynamically. See the documentation of [`FontSelectionFn`] for more
     /// details.
-    fn select_fallback(
-        &self,
-        c: char,
-        exclude_fonts: &[ID],
-        fontdb: &mut Arc<Database>,
-    ) -> Option<ID>;
+    fn select_fallback(&self, c: char, exclude_fonts: &[ID]) -> Option<ID>;
 }
 
 /// Default font resolver
@@ -74,10 +71,37 @@ pub trait FontResolver: Debug + Sync {
 ///
 /// The default fallback selector searches through the entire `fontdb`
 /// to find a font that has the correct style and supports the character.
-#[derive(Clone, Copy, Debug)]
-pub struct DefaultFontResolver;
+#[derive(Clone, Debug, Default)]
+pub struct DefaultFontResolver {
+    fontdb: Database,
+}
+
+impl DefaultFontResolver {
+    /// Construct from an existing [`Database`]
+    pub fn new(fontdb: Database) -> Self {
+        DefaultFontResolver { fontdb }
+    }
+
+    /// Construct, loading system fonts
+    #[cfg(feature = "system-fonts")]
+    pub fn with_system_fonts() -> Self {
+        let mut fontdb = fontdb::Database::new();
+        fontdb.load_system_fonts();
+        DefaultFontResolver { fontdb }
+    }
+
+    /// Deconstruct, taking the [`Database`]
+    pub fn take_db(self) -> Database {
+        self.fontdb
+    }
+}
+
 impl FontResolver for DefaultFontResolver {
-    fn select_font(&self, font: &Font, fontdb: &mut Arc<Database>) -> Option<ID> {
+    fn fontdb(&self) -> &Database {
+        &self.fontdb
+    }
+
+    fn select_font(&self, font: &Font) -> Option<ID> {
         let mut name_list = Vec::new();
         for family in &font.families {
             name_list.push(match family {
@@ -118,7 +142,7 @@ impl FontResolver for DefaultFontResolver {
             style,
         };
 
-        let id = fontdb.query(&query);
+        let id = self.fontdb.query(&query);
         if id.is_none() {
             log::warn!(
                 "No match for '{}' font-family.",
@@ -133,23 +157,18 @@ impl FontResolver for DefaultFontResolver {
         id
     }
 
-    fn select_fallback(
-        &self,
-        c: char,
-        exclude_fonts: &[ID],
-        fontdb: &mut Arc<Database>,
-    ) -> Option<ID> {
+    fn select_fallback(&self, c: char, exclude_fonts: &[ID]) -> Option<ID> {
         let base_font_id = exclude_fonts[0];
 
         // Iterate over fonts and check if any of them support the specified char.
-        for face in fontdb.faces() {
+        for face in self.fontdb.faces() {
             // Ignore fonts, that were used for shaping already.
             if exclude_fonts.contains(&face.id) {
                 continue;
             }
 
             // Check that the new face has the same style.
-            let base_face = fontdb.face(base_font_id)?;
+            let base_face = self.fontdb.face(base_font_id)?;
             if base_face.style != face.style
                 && base_face.weight != face.weight
                 && base_face.stretch != face.stretch
@@ -157,7 +176,7 @@ impl FontResolver for DefaultFontResolver {
                 continue;
             }
 
-            if !fontdb.has_char(face.id, c) {
+            if !self.fontdb.has_char(face.id, c) {
                 continue;
             }
 
@@ -186,17 +205,13 @@ impl FontResolver for DefaultFontResolver {
 /// SVG specifiation. While doing so, we also calculate the text bbox (which is not based on the
 /// outlines of a glyph, but instead the glyph metrics as well as decoration spans).
 /// 2. We convert all of the positioned glyphs into outlines.
-pub(crate) fn convert(
-    text: &mut Text,
-    resolver: &dyn FontResolver,
-    fontdb: &mut Arc<fontdb::Database>,
-) -> Option<()> {
-    let (text_fragments, bbox) = layout::layout_text(text, resolver, fontdb)?;
+pub(crate) fn convert(text: &mut Text, resolver: &dyn FontResolver) -> Option<()> {
+    let (text_fragments, bbox) = layout::layout_text(text, resolver)?;
     text.layouted = text_fragments;
     text.bounding_box = bbox.to_rect();
     text.abs_bounding_box = bbox.transform(text.abs_transform)?.to_rect();
 
-    let (group, stroke_bbox) = flatten::flatten(text, fontdb)?;
+    let (group, stroke_bbox) = flatten::flatten(text, resolver.fontdb())?;
     text.flattened = Box::new(group);
     text.stroke_bounding_box = stroke_bbox.to_rect();
     text.abs_stroke_bounding_box = stroke_bbox.transform(text.abs_transform)?.to_rect();

--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -1545,8 +1545,6 @@ pub struct Tree {
     pub(crate) clip_paths: Vec<Arc<ClipPath>>,
     pub(crate) masks: Vec<Arc<Mask>>,
     pub(crate) filters: Vec<Arc<filter::Filter>>,
-    #[cfg(feature = "text")]
-    pub(crate) fontdb: Arc<fontdb::Database>,
 }
 
 impl Tree {
@@ -1608,12 +1606,6 @@ impl Tree {
     /// Returns a list of all unique [`Filter`](filter::Filter)s in the tree.
     pub fn filters(&self) -> &[Arc<filter::Filter>] {
         &self.filters
-    }
-
-    /// Returns the font database that applies to all text nodes in the tree.
-    #[cfg(feature = "text")]
-    pub fn fontdb(&self) -> &Arc<fontdb::Database> {
-        &self.fontdb
     }
 
     pub(crate) fn collect_paint_servers(&mut self) {


### PR DESCRIPTION
# Summary

`usvg::FontResolver` is changed from a struct to a trait, with a default implementation `DefaultFontResolver`.

`usvg::Options` and `usvg::Tree` no longer contain `fontdb`; instead then `FontResolver` provides access as required.

# Motivation

The existing model:

- Requires that the `fontdb` be shared under an `Arc`, which shouldn't be necessary
- Clones the `fontdb` before modifying
- Makes the modified `fontdb` accessible through `usvg::Tree`, which doesn't appear to be the right place for it

Instead, the user is expected to provide a `&dyn FontResolver` instance in order to process any SVG involving text. As a consequence:

- The user may use an existing `fontdb` instance (without cloning) and may even insert additional fonts directly into this DB (via `RefCell`, `Mutex` or similar)
- The user may retrieve the original `fontdb` instance used without `Arc`
- The minimal set-up with working text processing is slightly more complex (and unfortunately runs into a borrow-checker error if `font_resolver` is not declared before `usvg::Options`).