### PR TITLE
feat: add raw image to allow flexible resolvers

### DIFF
--- a/crates/resvg/src/image.rs
+++ b/crates/resvg/src/image.rs
@@ -56,6 +56,8 @@ fn render_vector(
 
 #[cfg(feature = "raster-images")]
 mod raster_images {
+    use usvg::RawImage;
+
     use crate::OptionLog;
 
     fn decode_raster(image: &usvg::ImageKind) -> Option<tiny_skia::Pixmap> {
@@ -72,6 +74,9 @@ mod raster_images {
             }
             usvg::ImageKind::WEBP(ref data) => {
                 decode_webp(data).log_none(|| log::warn!("Failed to decode a WebP image."))
+            }
+            usvg::ImageKind::RAW(RawImage { size, ref data }) => {
+                tiny_skia::Pixmap::from_vec(data.to_vec(), size.to_int_size()).into()
             }
         }
     }

--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -1415,6 +1415,13 @@ impl Path {
     }
 }
 
+// Raw RGBA image data
+#[derive(Clone)]
+pub struct RawImage {
+    pub data: Arc<Vec<u8>>,
+    pub size: Size,
+}
+
 /// An embedded image kind.
 #[derive(Clone)]
 pub enum ImageKind {
@@ -1426,6 +1433,7 @@ pub enum ImageKind {
     GIF(Arc<Vec<u8>>),
     /// A reference to raw WebP data. Should be decoded by the caller.
     WEBP(Arc<Vec<u8>>),
+    RAW(RawImage),
     /// A preprocessed SVG tree. Can be rendered as is.
     SVG(Tree),
 }
@@ -1440,6 +1448,7 @@ impl ImageKind {
                 .ok()
                 .and_then(|size| Size::from_wh(size.width as f32, size.height as f32))
                 .log_none(|| log::warn!("Image has an invalid size. Skipped.")),
+            ImageKind::RAW(RawImage { size, data: _ }) => (*size).into(),
             ImageKind::SVG(ref svg) => Some(svg.size),
         }
     }
@@ -1452,6 +1461,7 @@ impl std::fmt::Debug for ImageKind {
             ImageKind::PNG(_) => f.write_str("ImageKind::PNG(..)"),
             ImageKind::GIF(_) => f.write_str("ImageKind::GIF(..)"),
             ImageKind::WEBP(_) => f.write_str("ImageKind::WEBP(..)"),
+            ImageKind::RAW(_) => f.write_str("ImageKind::RAW(..)"),
             ImageKind::SVG(_) => f.write_str("ImageKind::SVG(..)"),
         }
     }

--- a/crates/usvg/src/writer.rs
+++ b/crates/usvg/src/writer.rs
@@ -1070,18 +1070,21 @@ impl XmlWriterExt for XmlWriter {
     fn write_image_data(&mut self, kind: &ImageKind) {
         let svg_string;
         let (mime, data) = match kind {
-            ImageKind::JPEG(ref data) => ("jpeg", data.as_slice()),
-            ImageKind::PNG(ref data) => ("png", data.as_slice()),
-            ImageKind::GIF(ref data) => ("gif", data.as_slice()),
-            ImageKind::WEBP(ref data) => ("webp", data.as_slice()),
+            ImageKind::JPEG(ref data) => ("image/jpeg", data.as_slice()),
+            ImageKind::PNG(ref data) => ("image/png", data.as_slice()),
+            ImageKind::GIF(ref data) => ("image/gif", data.as_slice()),
+            ImageKind::WEBP(ref data) => ("image/webp", data.as_slice()),
+            ImageKind::RAW(RawImage { size: _, ref data }) => {
+                ("application/octet-stream", data.as_slice())
+            }
             ImageKind::SVG(ref tree) => {
                 svg_string = tree.to_string(&WriteOptions::default());
-                ("svg+xml", svg_string.as_bytes())
+                ("image/svg+xml", svg_string.as_bytes())
             }
         };
 
         self.write_attribute_raw("xlink:href", |buf| {
-            buf.extend_from_slice(b"data:image/");
+            buf.extend_from_slice(b"data:");
             buf.extend_from_slice(mime.as_bytes());
             buf.extend_from_slice(b";base64, ");
 


### PR DESCRIPTION
Adds a RawImage image kind to usvg and a transparent decode_raster implementation in resvg. This allows writing flexible ImageHrefResolver that can support additional image formats.  Another use case would be to allow alternate implementations, but with zunejpeg merged, I find it less important.

Closes #772 

I'm unsure about the xml writer implementation, but I've added a hack for now