### PR TITLE
Add the cargo-c metadata

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -26,3 +26,10 @@ system-fonts = ["resvg/system-fonts"]
 # enables font files memmaping for faster loading (only for `text`)
 memmap-fonts = ["resvg/memmap-fonts"]
 raster-images = ["resvg/raster-images"]
+capi = []
+
+[package.metadata.capi.header]
+generation = false
+
+[package.metadata.capi.install.include]
+asset = [{ from="resvg.h" }]


### PR DESCRIPTION
Fixes #592

The default `cargo cinstall --destdir some/path` produces on macos:
```
└── usr
    └── local
        ├── include
        │   └── resvg
        │       └── resvg.h
        └── lib
            ├── libresvg.0.43.0.dylib
            ├── libresvg.0.43.dylib -> libresvg.0.43.0.dylib
            ├── libresvg.a
            ├── libresvg.dylib -> libresvg.0.43.0.dylib
            └── pkgconfig
                └── resvg.pc
```