### PR TITLE
impl From for FontStretch, FontStyle

### DIFF
--- a/crates/usvg/src/tree/text.rs
+++ b/crates/usvg/src/tree/text.rs
@@ -33,6 +33,40 @@ impl Default for FontStretch {
     }
 }
 
+#[cfg(feature = "text")]
+impl From<fontdb::Stretch> for FontStretch {
+    fn from(stretch: fontdb::Stretch) -> Self {
+        match stretch {
+            fontdb::Stretch::UltraCondensed => FontStretch::UltraCondensed,
+            fontdb::Stretch::ExtraCondensed => FontStretch::ExtraCondensed,
+            fontdb::Stretch::Condensed => FontStretch::Condensed,
+            fontdb::Stretch::SemiCondensed => FontStretch::SemiCondensed,
+            fontdb::Stretch::Normal => FontStretch::Normal,
+            fontdb::Stretch::SemiExpanded => FontStretch::SemiExpanded,
+            fontdb::Stretch::Expanded => FontStretch::Expanded,
+            fontdb::Stretch::ExtraExpanded => FontStretch::ExtraExpanded,
+            fontdb::Stretch::UltraExpanded => FontStretch::UltraExpanded,
+        }
+    }
+}
+
+#[cfg(feature = "text")]
+impl From<FontStretch> for fontdb::Stretch {
+    fn from(stretch: FontStretch) -> Self {
+        match stretch {
+            FontStretch::UltraCondensed => fontdb::Stretch::UltraCondensed,
+            FontStretch::ExtraCondensed => fontdb::Stretch::ExtraCondensed,
+            FontStretch::Condensed => fontdb::Stretch::Condensed,
+            FontStretch::SemiCondensed => fontdb::Stretch::SemiCondensed,
+            FontStretch::Normal => fontdb::Stretch::Normal,
+            FontStretch::SemiExpanded => fontdb::Stretch::SemiExpanded,
+            FontStretch::Expanded => fontdb::Stretch::Expanded,
+            FontStretch::ExtraExpanded => fontdb::Stretch::ExtraExpanded,
+            FontStretch::UltraExpanded => fontdb::Stretch::UltraExpanded,
+        }
+    }
+}
+
 /// A font style property.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub enum FontStyle {
@@ -48,6 +82,28 @@ impl Default for FontStyle {
     #[inline]
     fn default() -> FontStyle {
         Self::Normal
+    }
+}
+
+#[cfg(feature = "text")]
+impl From<fontdb::Style> for FontStyle {
+    fn from(style: fontdb::Style) -> Self {
+        match style {
+            fontdb::Style::Normal => FontStyle::Normal,
+            fontdb::Style::Italic => FontStyle::Italic,
+            fontdb::Style::Oblique => FontStyle::Oblique,
+        }
+    }
+}
+
+#[cfg(feature = "text")]
+impl From<FontStyle> for fontdb::Style {
+    fn from(style: FontStyle) -> Self {
+        match style {
+            FontStyle::Normal => fontdb::Style::Normal,
+            FontStyle::Italic => fontdb::Style::Italic,
+            FontStyle::Oblique => fontdb::Style::Oblique,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #808.

I added a CI test for `usvg` with all features since this was not present.

Note also:

- `fontdb::Weight` could include `From<u16>`, but this is relatively unimportant
- `svgtypes::FontFamily` could implement `From<fontdb::FontFamily>`; the reverse would need to be `fontdb::FontFamily<'a>: From<&'a svgtypes::FontFamily>` (omitted since this is a different repo)
- `fontdb::Query<'a>` cannot implement `From<usvg::Font>` (or `&'a usvg::Font`) due to lifetime of the list of `families`.