### PR TITLE
Fix bounding box returned by resvg_get_image_bbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog also contains important changes in dependencies.
 ## [Unreleased]
 ### Fixed
 - (svgtypes) Path parsing with `S` or `T` segments after `A`.
+- (c-api) `resvg_get_image_bbox` returns correct bounding box.
 
 ## [0.43.0] - 2024-08-10
 ### Added

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -612,7 +612,8 @@ pub extern "C" fn resvg_get_image_bbox(
         &*tree
     };
 
-    if let Some(r) = tree.0.root().abs_bounding_box().to_non_zero_rect() {
+    if tree.0.root().abs_bounding_box().to_non_zero_rect().is_some() {
+        let r = tree.0.root().abs_layer_bounding_box();
         unsafe {
             *bbox = resvg_rect {
                 x: r.x(),


### PR DESCRIPTION
This was using abs_bounding_box before which, amongst other things, didn't include the full boundary box for text. This change swaps to using abs_layer_bounding_box which will return a bounding box including stroke, filters and text.

This will only return `true` in the same circumstances that the function previously did - since `abs_layer_bounding_box()` returns a non-zero rect, it can potentially be invalid (width/height set to 1) - so check if there is any valid bounding box, then return the correct one.

Relates to/Fixes #823 