### PR TITLE
Upgrade image-webp to 0.2.x get bugfixes and major optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "image-webp"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+checksum = "e031e8e3d94711a9ccb5d6ea357439ef3dcbed361798bd4071dc4d9793fbe22f"
 dependencies = [
  "byteorder-lite",
  "quick-error",

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -16,7 +16,7 @@ required-features = ["text", "system-fonts", "memmap-fonts"]
 
 [dependencies]
 gif = { version = "0.13", optional = true }
-image-webp = { version = "0.1.3", optional = true }
+image-webp = { version = "0.2.0", optional = true }
 log = "0.4"
 pico-args = { version = "0.5", features = ["eq-separator"] }
 rgb = "0.8"


### PR DESCRIPTION
I know that PRs for updates to dependencies usually aren't welcome, but this cannot be taken care of by a `cargo update` because 0.1.x to 0.2.x is a semver-incompatible change, and needs to be done in resvg's `Cargo.toml`

Changelog: https://github.com/image-rs/image-webp/blob/main/CHANGES.md