### PR TITLE
Decouple the build of viewsvg from that of resvg

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -22,6 +22,7 @@ jobs:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}
           body: |
+            - `viewsvg` is a simple application that showcases *resvg* capabilities
             - `resvg-0.*.0.tar.xz` is a sources archive with vendored Rust dependencies
             - `resvg-explorer-extension.exe` is an SVG thumbnailer for Windows Explorer
 
@@ -88,7 +89,7 @@ jobs:
 
   release-windows:
     name: Release Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: ["create-release"]
     steps:
       - name: Checkout
@@ -126,6 +127,11 @@ jobs:
         run: |
           "%programfiles(x86)%\Inno Setup 6\iscc.exe" "installer.iss"
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
       # Unlike other binaries, viewsvg isn't built with crt-static
       - name: Build C API
         working-directory: crates/c-api
@@ -134,12 +140,24 @@ jobs:
       - name: Prepare Developer Command Prompt for MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          nmake
+          mkdir viewsvg-bin
+          cp release/viewsvg.exe viewsvg-bin/viewsvg.exe
+          windeployqt --no-translations viewsvg-bin/viewsvg.exe
+          cd viewsvg-bin
+          7z a -tzip -mx9 viewsvg-win64.zip *
+
       - name: Collect
         run: |
           mkdir bin
           cp target/release/resvg-win64.zip bin/
           cp target/release/usvg-win64.zip bin/
           cp tools/explorer-thumbnailer/install/resvg-explorer-extension.exe bin/
+          cp tools/viewsvg/viewsvg-bin/viewsvg-win64.zip bin/
 
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -53,7 +53,7 @@ jobs:
           strip -s usvg
           tar czf resvg-linux-x86_64.tar.gz resvg
           tar czf usvg-linux-x86_64.tar.gz usvg
-          mkdir -p ../../bin
+          mkdir ../../bin
           cp resvg-linux-x86_64.tar.gz ../../bin/
           cp usvg-linux-x86_64.tar.gz ../../bin/
 

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -37,7 +37,7 @@ jobs:
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build resvg
         run: cargo build --release
@@ -92,7 +92,7 @@ jobs:
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Toolchain is stable-x86_64-pc-windows-msvc by default. No need to change it.
 
@@ -150,11 +150,11 @@ jobs:
 
   release-macos:
     name: Release macOS
-    runs-on: macos-13
+    runs-on: macos-15
     needs: ["create-release"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Some weird CI glitch. Make sure we have the latest Rust.
       - name: Install latest stable toolchain
@@ -177,11 +177,27 @@ jobs:
         working-directory: crates/c-api
         run: cargo build --release
 
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          make
+          macdeployqt viewsvg.app
+          rm -r viewsvg.app/Contents/Plugins/iconengines
+          rm -r viewsvg.app/Contents/Plugins/imageformats
+          7z a -tzip -mx9 viewsvg-macos-x86_64.zip viewsvg.app
+
       - name: Collect
         run: |
           mkdir bin
           cp target/release/resvg-macos-x86_64.zip bin/
           cp target/release/usvg-macos-x86_64.zip bin/
+          cp tools/viewsvg/viewsvg-macos-x86_64.zip bin/
 
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -34,7 +34,7 @@ jobs:
 
   release-linux:
     name: Release Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: ["create-release"]
     steps:
       - name: Checkout
@@ -54,9 +54,75 @@ jobs:
           strip -s usvg
           tar czf resvg-linux-x86_64.tar.gz resvg
           tar czf usvg-linux-x86_64.tar.gz usvg
-          mkdir ../../bin
+          mkdir -p ../../bin
           cp resvg-linux-x86_64.tar.gz ../../bin/
           cp usvg-linux-x86_64.tar.gz ../../bin/
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
+      - name: Build C API
+        working-directory: crates/c-api
+        run: cargo build --release
+
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          make
+
+          # Create AppDir structure
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/lib
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+
+          # Copy viewsvg binary
+          cp viewsvg AppDir/usr/bin/
+
+          # Copy libresvg.so and set correct permissions
+          cp ../../target/release/libresvg.so AppDir/usr/lib/
+          chmod +x AppDir/usr/lib/libresvg.so
+
+          # Create a simple SVG icon as fallback
+          cat > AppDir/usr/share/icons/hicolor/256x256/apps/viewsvg.svg << EOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+            <rect width="256" height="256" fill="#4d4d4d"/>
+            <text x="128" y="128" font-family="sans-serif" font-size="40" fill="white" text-anchor="middle" dominant-baseline="middle">SVG</text>
+          </svg>
+          EOF
+
+      - name: Create AppImage
+        working-directory: tools/viewsvg
+        run: |
+          # Install linuxdeploy and Qt plugin
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
+
+          # Create .desktop file with icon reference
+          mkdir -p AppDir/usr/share/applications
+          cat > AppDir/usr/share/applications/viewsvg.desktop << EOF
+          [Desktop Entry]
+          Type=Application
+          Name=ViewSVG
+          Comment=Simple SVG viewer
+          Exec=viewsvg
+          Icon=viewsvg
+          Categories=Graphics;Viewer;
+          EOF
+
+          # Add library path to environment
+          export LD_LIBRARY_PATH=AppDir/usr/lib:$LD_LIBRARY_PATH
+
+          # Create AppImage with library path
+          export OUTPUT=viewsvg-x86_64.AppImage
+          ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin=qt --output=appimage
+
+          # Compress AppImage
+          7z a -tzip -mx9 viewsvg-linux-x86_64.zip viewsvg-x86_64.AppImage
 
       - name: Get version
         id: get_version
@@ -79,6 +145,10 @@ jobs:
               --exclude="resvg-$VERSION/docs" \
               -cJf resvg-"$VERSION".tar.xz resvg-"$VERSION"
           cp resvg-"$VERSION".tar.xz bin/
+
+      - name: Collect viewsvg binary
+        run: |
+          cp tools/viewsvg/viewsvg-linux-x86_64.zip bin/
 
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   create-release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Create Release
         id: create_release
@@ -22,7 +22,6 @@ jobs:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}
           body: |
-            - `viewsvg` is a simple application that showcases *resvg* capabilities
             - `resvg-0.*.0.tar.xz` is a sources archive with vendored Rust dependencies
             - `resvg-explorer-extension.exe` is an SVG thumbnailer for Windows Explorer
 
@@ -58,71 +57,9 @@ jobs:
           cp resvg-linux-x86_64.tar.gz ../../bin/
           cp usvg-linux-x86_64.tar.gz ../../bin/
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4.2.1
-        with:
-          version: '6.8.3'
-
       - name: Build C API
         working-directory: crates/c-api
         run: cargo build --release
-
-      - name: Build viewsvg
-        working-directory: tools/viewsvg
-        run: |
-          qmake6
-          make
-
-          # Create AppDir structure
-          mkdir -p AppDir/usr/bin
-          mkdir -p AppDir/usr/lib
-          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-
-          # Copy viewsvg binary
-          cp viewsvg AppDir/usr/bin/
-
-          # Copy libresvg.so and set correct permissions
-          cp ../../target/release/libresvg.so AppDir/usr/lib/
-          chmod +x AppDir/usr/lib/libresvg.so
-
-          # Create a simple SVG icon as fallback
-          cat > AppDir/usr/share/icons/hicolor/256x256/apps/viewsvg.svg << EOF
-          <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
-            <rect width="256" height="256" fill="#4d4d4d"/>
-            <text x="128" y="128" font-family="sans-serif" font-size="40" fill="white" text-anchor="middle" dominant-baseline="middle">SVG</text>
-          </svg>
-          EOF
-
-      - name: Create AppImage
-        working-directory: tools/viewsvg
-        run: |
-          # Install linuxdeploy and Qt plugin
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-          wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
-          chmod +x linuxdeploy-x86_64.AppImage
-          chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
-
-          # Create .desktop file with icon reference
-          mkdir -p AppDir/usr/share/applications
-          cat > AppDir/usr/share/applications/viewsvg.desktop << EOF
-          [Desktop Entry]
-          Type=Application
-          Name=ViewSVG
-          Comment=Simple SVG viewer
-          Exec=viewsvg
-          Icon=viewsvg
-          Categories=Graphics;Viewer;
-          EOF
-
-          # Add library path to environment
-          export LD_LIBRARY_PATH=AppDir/usr/lib:$LD_LIBRARY_PATH
-
-          # Create AppImage with library path
-          export OUTPUT=viewsvg-x86_64.AppImage
-          ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin=qt --output=appimage
-
-          # Compress AppImage
-          7z a -tzip -mx9 viewsvg-linux-x86_64.zip viewsvg-x86_64.AppImage
 
       - name: Get version
         id: get_version
@@ -146,10 +83,6 @@ jobs:
               -cJf resvg-"$VERSION".tar.xz resvg-"$VERSION"
           cp resvg-"$VERSION".tar.xz bin/
 
-      - name: Collect viewsvg binary
-        run: |
-          cp tools/viewsvg/viewsvg-linux-x86_64.zip bin/
-
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2
         env:
@@ -166,7 +99,6 @@ jobs:
         uses: actions/checkout@v4
 
       # Toolchain is stable-x86_64-pc-windows-msvc by default. No need to change it.
-
       - name: Build resvg
         env:
           RUSTFLAGS: -Ctarget-feature=+crt-static # make sure it's static
@@ -197,11 +129,6 @@ jobs:
         run: |
           "%programfiles(x86)%\Inno Setup 6\iscc.exe" "installer.iss"
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4.2.1
-        with:
-          version: '6.8.3'
-
       # Unlike other binaries, viewsvg isn't built with crt-static
       - name: Build C API
         working-directory: crates/c-api
@@ -210,24 +137,12 @@ jobs:
       - name: Prepare Developer Command Prompt for MSVC
         uses: ilammy/msvc-dev-cmd@v1
 
-      - name: Build viewsvg
-        working-directory: tools/viewsvg
-        run: |
-          qmake6
-          nmake
-          mkdir viewsvg-bin
-          cp release/viewsvg.exe viewsvg-bin/viewsvg.exe
-          windeployqt --no-translations viewsvg-bin/viewsvg.exe
-          cd viewsvg-bin
-          7z a -tzip -mx9 viewsvg-win64.zip *
-
       - name: Collect
         run: |
           mkdir bin
           cp target/release/resvg-win64.zip bin/
           cp target/release/usvg-win64.zip bin/
           cp tools/explorer-thumbnailer/install/resvg-explorer-extension.exe bin/
-          cp tools/viewsvg/viewsvg-bin/viewsvg-win64.zip bin/
 
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2
@@ -265,27 +180,11 @@ jobs:
         working-directory: crates/c-api
         run: cargo build --release
 
-      - name: Install Qt
-        uses: jurplel/install-qt-action@v4.2.1
-        with:
-          version: '6.8.3'
-
-      - name: Build viewsvg
-        working-directory: tools/viewsvg
-        run: |
-          qmake6
-          make
-          macdeployqt viewsvg.app
-          rm -r viewsvg.app/Contents/Plugins/iconengines
-          rm -r viewsvg.app/Contents/Plugins/imageformats
-          7z a -tzip -mx9 viewsvg-macos-x86_64.zip viewsvg.app
-
       - name: Collect
         run: |
           mkdir bin
           cp target/release/resvg-macos-x86_64.zip bin/
           cp target/release/usvg-macos-x86_64.zip bin/
-          cp tools/viewsvg/viewsvg-macos-x86_64.zip bin/
 
       - name: Upload binaries
         uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/viewsvg-release.yml
+++ b/.github/workflows/viewsvg-release.yml
@@ -332,9 +332,10 @@ jobs:
           CURRENT_BODY=$(echo $RELEASE_INFO | jq -r .body)
 
           # Check if the line already exists in the body
-          if [[ "$CURRENT_BODY" != *"viewsvg is a simple application that showcases resvg capabilities"* ]]; then
-            # Append the line to the beginning of the body
-            NEW_BODY="- viewsvg is a simple application that showcases resvg capabilities $CURRENT_BODY"
+          if [[ "$CURRENT_BODY" != *'`viewsvg` is a simple application that showcases resvg capabilities'* ]]; then
+            # Create new body with line at beginning
+            NEW_LINE='- `viewsvg` is a simple application that showcases resvg capabilities'
+            NEW_BODY=$(echo -e "$NEW_LINE\n$CURRENT_BODY")
 
             # Update the release body
             curl -s -X PATCH \

--- a/.github/workflows/viewsvg-release.yml
+++ b/.github/workflows/viewsvg-release.yml
@@ -1,0 +1,349 @@
+name: "ViewSVG Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to append binaries to (e.g. v0.30.0, leave empty for latest)'
+        required: false
+        type: string
+        default: ''
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare-release:
+    name: Prepare Release Info
+    runs-on: ubuntu-24.04
+    outputs:
+      upload_url: ${{ steps.get_release.outputs.upload_url }}
+      release_tag: ${{ steps.determine_tag.outputs.release_tag }}
+      release_id: ${{ steps.get_release.outputs.release_id }}
+    steps:
+      - name: Determine release tag
+        id: determine_tag
+        run: |
+          if [[ -z "${{ github.event.inputs.release_tag }}" ]]; then
+            LATEST_RELEASE=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+            echo "Using latest release: ${LATEST_RELEASE}"
+            echo "release_tag=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
+          else
+            echo "Using specified release: ${{ github.event.inputs.release_tag }}"
+            echo "release_tag=${{ github.event.inputs.release_tag }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Get release
+        id: get_release
+        run: |
+          RELEASE_TAG="${{ steps.determine_tag.outputs.release_tag }}"
+          RELEASE_INFO=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${RELEASE_TAG})
+          UPLOAD_URL=$(echo $RELEASE_INFO | jq -r .upload_url)
+          RELEASE_ID=$(echo $RELEASE_INFO | jq -r .id)
+
+          if [[ "$UPLOAD_URL" == "null" ]]; then
+            echo "::error::Could not find release with tag ${RELEASE_TAG}"
+            exit 1
+          fi
+
+          echo "Found release URL: ${UPLOAD_URL}"
+          echo "upload_url=${UPLOAD_URL}" >> $GITHUB_OUTPUT
+          echo "release_id=${RELEASE_ID}" >> $GITHUB_OUTPUT
+
+  viewsvg-linux:
+    name: Build ViewSVG for Linux
+    runs-on: ubuntu-24.04
+    needs: ["prepare-release"]
+    outputs:
+      success: ${{ steps.build_success.outputs.success }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Build C API
+        working-directory: crates/c-api
+        run: cargo build --release
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          make
+
+          # Create AppDir structure
+          mkdir -p AppDir/usr/bin
+          mkdir -p AppDir/usr/lib
+          mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+
+          # Copy viewsvg binary
+          cp viewsvg AppDir/usr/bin/
+
+          # Copy libresvg.so and set correct permissions
+          cp ../../target/release/libresvg.so AppDir/usr/lib/
+          chmod +x AppDir/usr/lib/libresvg.so
+
+          # Create a simple SVG icon as fallback
+          cat > AppDir/usr/share/icons/hicolor/256x256/apps/viewsvg.svg << EOF
+          <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+            <rect width="256" height="256" fill="#4d4d4d"/>
+            <text x="128" y="128" font-family="sans-serif" font-size="40" fill="white" text-anchor="middle" dominant-baseline="middle">SVG</text>
+          </svg>
+          EOF
+
+      - name: Create AppImage
+        working-directory: tools/viewsvg
+        run: |
+          # Install linuxdeploy and Qt plugin
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          wget https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+          chmod +x linuxdeploy-x86_64.AppImage
+          chmod +x linuxdeploy-plugin-qt-x86_64.AppImage
+
+          # Create .desktop file with icon reference
+          mkdir -p AppDir/usr/share/applications
+          cat > AppDir/usr/share/applications/viewsvg.desktop << EOF
+          [Desktop Entry]
+          Type=Application
+          Name=ViewSVG
+          Comment=Simple SVG viewer
+          Exec=viewsvg
+          Icon=viewsvg
+          Categories=Graphics;Viewer;
+          EOF
+
+          # Add library path to environment
+          export LD_LIBRARY_PATH=AppDir/usr/lib:$LD_LIBRARY_PATH
+
+          # Create AppImage with library path
+          export OUTPUT=viewsvg-x86_64.AppImage
+          ./linuxdeploy-x86_64.AppImage --appdir=AppDir --plugin=qt --output=appimage
+
+          # Compress AppImage
+          7z a -tzip -mx9 viewsvg-linux-x86_64.zip viewsvg-x86_64.AppImage
+
+      - name: Collect viewsvg binary
+        run: |
+          mkdir -p bin
+          cp tools/viewsvg/viewsvg-linux-x86_64.zip bin/
+
+      - name: Check for existing asset and remove if found
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_ID="${{ needs.prepare-release.outputs.release_id }}"
+          ASSET_NAME="viewsvg-linux-x86_64.zip"
+
+          # Get list of assets
+          ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets")
+
+          # Find asset ID for the given name if it exists
+          ASSET_ID=$(echo "$ASSETS" | jq -r ".[] | select(.name == \"$ASSET_NAME\") | .id")
+
+          if [[ ! -z "$ASSET_ID" ]]; then
+            echo "Found existing asset with ID: $ASSET_ID, removing it..."
+            curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ASSET_ID"
+          else
+            echo "No existing asset found with name: $ASSET_NAME"
+          fi
+
+      - name: Upload Linux binary to release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.prepare-release.outputs.upload_url }}
+          asset_path: bin/viewsvg-linux-x86_64.zip
+          asset_name: viewsvg-linux-x86_64.zip
+          asset_content_type: application/zip
+
+      - name: Set success output
+        id: build_success
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  viewsvg-windows:
+    name: Build ViewSVG for Windows
+    runs-on: windows-2022
+    needs: ["prepare-release"]
+    outputs:
+      success: ${{ steps.build_success.outputs.success }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Build C API
+        working-directory: crates/c-api
+        run: cargo build --release
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
+      - name: Prepare Developer Command Prompt for MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          nmake
+          mkdir viewsvg-bin
+          cp release/viewsvg.exe viewsvg-bin/viewsvg.exe
+          windeployqt --no-translations viewsvg-bin/viewsvg.exe
+          cd viewsvg-bin
+          7z a -tzip -mx9 viewsvg-win64.zip *
+
+      - name: Collect
+        run: |
+          mkdir bin
+          cp tools/viewsvg/viewsvg-bin/viewsvg-win64.zip bin/
+
+      - name: Check for existing asset and remove if found
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_ID="${{ needs.prepare-release.outputs.release_id }}"
+          ASSET_NAME="viewsvg-win64.zip"
+
+          # Get list of assets
+          ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets")
+
+          # Find asset ID for the given name if it exists
+          ASSET_ID=$(echo "$ASSETS" | jq -r ".[] | select(.name == \"$ASSET_NAME\") | .id")
+
+          if [[ ! -z "$ASSET_ID" ]]; then
+            echo "Found existing asset with ID: $ASSET_ID, removing it..."
+            curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ASSET_ID"
+          else
+            echo "No existing asset found with name: $ASSET_NAME"
+          fi
+
+      - name: Upload Windows binary to release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.prepare-release.outputs.upload_url }}
+          asset_path: bin/viewsvg-win64.zip
+          asset_name: viewsvg-win64.zip
+          asset_content_type: application/zip
+
+      - name: Set success output
+        id: build_success
+        shell: bash
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  viewsvg-macos:
+    name: Build ViewSVG for macOS
+    runs-on: macos-15
+    needs: ["prepare-release"]
+    outputs:
+      success: ${{ steps.build_success.outputs.success }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-release.outputs.release_tag }}
+
+      - name: Install latest stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build C API
+        working-directory: crates/c-api
+        run: cargo build --release
+
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v4.2.1
+        with:
+          version: '6.8.3'
+
+      - name: Build viewsvg
+        working-directory: tools/viewsvg
+        run: |
+          qmake6
+          make
+          macdeployqt viewsvg.app
+          rm -r viewsvg.app/Contents/Plugins/iconengines
+          rm -r viewsvg.app/Contents/Plugins/imageformats
+          7z a -tzip -mx9 viewsvg-macos-x86_64.zip viewsvg.app
+
+      - name: Collect
+        run: |
+          mkdir bin
+          cp tools/viewsvg/viewsvg-macos-x86_64.zip bin/
+
+      - name: Check for existing asset and remove if found
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_ID="${{ needs.prepare-release.outputs.release_id }}"
+          ASSET_NAME="viewsvg-macos-x86_64.zip"
+
+          # Get list of assets
+          ASSETS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets")
+
+          # Find asset ID for the given name if it exists
+          ASSET_ID=$(echo "$ASSETS" | jq -r ".[] | select(.name == \"$ASSET_NAME\") | .id")
+
+          if [[ ! -z "$ASSET_ID" ]]; then
+            echo "Found existing asset with ID: $ASSET_ID, removing it..."
+            curl -s -X DELETE -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/assets/$ASSET_ID"
+          else
+            echo "No existing asset found with name: $ASSET_NAME"
+          fi
+
+      - name: Upload macOS binary to release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          upload_url: ${{ needs.prepare-release.outputs.upload_url }}
+          asset_path: bin/viewsvg-macos-x86_64.zip
+          asset_name: viewsvg-macos-x86_64.zip
+          asset_content_type: application/zip
+
+      - name: Set success output
+        id: build_success
+        run: echo "success=true" >> $GITHUB_OUTPUT
+
+  update-release:
+    name: Update Release Description
+    runs-on: ubuntu-24.04
+    needs: ["prepare-release", "viewsvg-linux", "viewsvg-windows", "viewsvg-macos"]
+    if: |
+      always() && (
+        needs.viewsvg-linux.result == 'success' && needs.viewsvg-linux.outputs.success == 'true' ||
+        needs.viewsvg-windows.result == 'success' && needs.viewsvg-windows.outputs.success == 'true' ||
+        needs.viewsvg-macos.result == 'success' && needs.viewsvg-macos.outputs.success == 'true'
+      )
+    steps:
+      - name: Update release description
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_ID="${{ needs.prepare-release.outputs.release_id }}"
+          RELEASE_INFO=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}")
+          CURRENT_BODY=$(echo $RELEASE_INFO | jq -r .body)
+
+          # Check if the line already exists in the body
+          if [[ "$CURRENT_BODY" != *"viewsvg is a simple application that showcases resvg capabilities"* ]]; then
+            # Append the line to the beginning of the body
+            NEW_BODY="- viewsvg is a simple application that showcases resvg capabilities $CURRENT_BODY"
+
+            # Update the release body
+            curl -s -X PATCH \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github.v3+json" \
+              -d "{\"body\": $(echo "$NEW_BODY" | jq -s -R .)}" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}"
+
+            echo "Release description updated successfully."
+          else
+            echo "The viewsvg line already exists in the release description. No update needed."
+          fi

--- a/tools/viewsvg/.gitignore
+++ b/tools/viewsvg/.gitignore
@@ -1,1 +1,7 @@
 *.pro.user
+*.o
+moc_*
+viewsvg
+.*
+ui_*.h
+Makefile

--- a/tools/viewsvg/main.cpp
+++ b/tools/viewsvg/main.cpp
@@ -7,8 +7,6 @@
 
 int main(int argc, char *argv[])
 {
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
     QApplication a(argc, argv);
 
     MainWindow w;

--- a/tools/viewsvg/svgview.cpp
+++ b/tools/viewsvg/svgview.cpp
@@ -302,7 +302,7 @@ void SvgView::requestUpdate()
     m_timer.start(100, this);
 
     // Run method in the m_worker thread scope.
-    QTimer::singleShot(1, m_worker, [=](){
+    QTimer::singleShot(1, m_worker, [this, s](){
         m_worker->render(s);
     });
 }

--- a/tools/viewsvg/viewsvg.pro
+++ b/tools/viewsvg/viewsvg.pro
@@ -2,7 +2,7 @@ QT += core gui widgets
 
 TARGET = viewsvg
 TEMPLATE = app
-CONFIG += c++11
+CONFIG += c++20
 
 SOURCES += \
     main.cpp \


### PR DESCRIPTION
### Decouples the build of `viewsvg` from that of `resvg`

- Builds of `viewsvg` are now described in their own CI file (`viewsvg-release.yml`), **are manual**, and target a specific release tag. This workflow builds `viewsvg` for Windows, Linux and macOS, and adds their binaries inside the release that was targeted. Vast majority of changes have been moved to that file. See [my post below](https://github.com/linebender/resvg/pull/917#issuecomment-2859811558) for details and more screenshots  
![image](https://github.com/user-attachments/assets/b3c95e5e-72fc-4672-b41d-67245bb0186b)

- The changes outside of that new CI file are the following (detailed reasons [here](https://github.com/linebender/resvg/pull/917#issuecomment-2854175927)):
  - Update action `actions/checkout` to `v4`
  - Update runners to `macos-15`, `windows-2022` and `ubuntu-24.04`
  - Make use of C++20 inside the file `tools/viewsvg/viewsvg.pro` file (Qt6 requires >= C++17)
  - Remove `QApplication::setAttribute(Qt::AA_EnableHighDpiScaling)` from `tools/viewsvg/main.cpp` (default behavior in Qt6)
  - Make variable capture explicit inside lambdas in `tools/viewsvg/svgview.cpp`
