### PR TITLE
Add `Tree::max_size` to compute actual SVG size

### DIFF
--- a/crates/usvg/src/tree/mod.rs
+++ b/crates/usvg/src/tree/mod.rs
@@ -1573,6 +1573,15 @@ impl Tree {
         self.size
     }
 
+    /// Returns the actual size of the image, accounting for strokes, filters
+    /// and transforms.
+    ///
+    /// May exceed the original [`size`](Tree::size).
+    pub fn max_size(&self) -> Size {
+        let bbox = self.root().abs_layer_bounding_box();
+        Size::from_wh(bbox.width(), bbox.height()).unwrap_or(self.size)
+    }
+
     /// The root element of the SVG tree.
     pub fn root(&self) -> &Group {
         &self.root


### PR DESCRIPTION
This PR adds `Tree::max_size` to easily get the final rendered size of an SVG, including all strokes, filters, and transforms.

## Motivation

This reduces boilerplate for anyone who needs the actual canvas size, for example when computing a scaling `Transform` to fit the SVG into a target region and to help avoid memory overflows (see #814).