### PR TITLE
Run `oxipng` with default arguments

### DIFF
--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -112,12 +112,7 @@ pub fn render_inner(name: &str, test_mode: TestMode) -> usize {
     let make_ref_fn = || -> ! {
         pixmap.save_png(&png_path).unwrap();
         Command::new("oxipng")
-            .args([
-                "-o".to_owned(),
-                "6".to_owned(),
-                "-Z".to_owned(),
-                png_path.clone(),
-            ])
+            .args([png_path.clone()])
             .output()
             .unwrap();
         panic!("new reference image created");


### PR DESCRIPTION
I'm not sure why, but using this specific configuration takes aaaages to run, and for some reason just results in larger file sizes instead of smaller ones.