### PR TITLE
feat: Parse `light-dark()` CSS function by extracting the first argument and add tests.

### DIFF
--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -206,6 +206,8 @@ OPTIONS:
   --export-area-drawing         Use drawing's tight bounding box instead of image size.
                                 Used during normal rendering and not during --export-id
 
+  --color-scheme SCHEME         Sets the color scheme for resolving CSS light-dark() function
+                                [default: light] [possible values: light, dark]
   --perf                        Prints performance stats
   --quiet                       Disables warnings
 
@@ -240,6 +242,7 @@ struct CliArgs {
     skip_system_fonts: bool,
     list_fonts: bool,
     style_sheet: Option<path::PathBuf>,
+    color_scheme: usvg::ColorScheme,
 
     query_all: bool,
     export_id: Option<String>,
@@ -310,6 +313,9 @@ fn collect_args() -> Result<CliArgs, pico_args::Error> {
 
         export_area_drawing: input.contains("--export-area-drawing"),
         style_sheet: input.opt_value_from_str("--stylesheet").unwrap_or_default(),
+        color_scheme: input
+            .opt_value_from_fn("--color-scheme", parse_color_scheme)?
+            .unwrap_or_default(),
 
         perf: input.contains("--perf"),
         quiet: input.contains("--quiet"),
@@ -370,6 +376,14 @@ fn parse_languages(s: &str) -> Result<Vec<String>, String> {
     }
 
     Ok(langs)
+}
+
+fn parse_color_scheme(s: &str) -> Result<usvg::ColorScheme, String> {
+    match s.to_lowercase().as_str() {
+        "light" => Ok(usvg::ColorScheme::Light),
+        "dark" => Ok(usvg::ColorScheme::Dark),
+        _ => Err("invalid color scheme, expected 'light' or 'dark'".to_string()),
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -578,6 +592,7 @@ fn parse_args() -> Result<Args, String> {
         font_resolver: usvg::FontResolver::default(),
         fontdb: Arc::new(fontdb::Database::new()),
         style_sheet,
+        color_scheme: args.color_scheme,
     };
 
     Ok(Args {

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -21,7 +21,7 @@ mod text;
 #[cfg(feature = "text")]
 pub(crate) use converter::Cache;
 pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn};
-pub use options::Options;
+pub use options::{ColorScheme, Options};
 pub(crate) use svgtree::{AId, EId};
 
 /// List of all errors.
@@ -136,7 +136,12 @@ impl crate::Tree {
                     (opt.font_resolver.select_fallback)(c, used_fonts, db)
                 }),
             },
-            ..Options::default()
+            // Inherit font_family from parent
+            font_family: opt.font_family.clone(),
+            // Inherit style_sheet from parent
+            style_sheet: opt.style_sheet.clone(),
+            // Inherit color_scheme from parent so nested SVGs use the same scheme
+            color_scheme: opt.color_scheme,
         };
 
         Self::from_data(data, &nested_opt)
@@ -157,7 +162,7 @@ impl crate::Tree {
 
     /// Parses `Tree` from `roxmltree::Document`.
     pub fn from_xmltree(doc: &roxmltree::Document, opt: &Options) -> Result<Self, Error> {
-        let doc = svgtree::Document::parse_tree(doc, opt.style_sheet.as_deref())?;
+        let doc = svgtree::Document::parse_tree(doc, opt.style_sheet.as_deref(), opt.color_scheme)?;
         self::converter::convert_doc(&doc, opt)
     }
 }

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use crate::FontResolver;
 use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
+// TODO: Use svgtypes::ColorScheme once https://github.com/linebender/svgtypes/pull/59 is merged
 /// The color scheme preference for resolving CSS `light-dark()` function.
 ///
 /// The CSS `light-dark()` function allows specifying two color values where the first

--- a/crates/usvg/src/parser/options.rs
+++ b/crates/usvg/src/parser/options.rs
@@ -8,6 +8,23 @@ use std::sync::Arc;
 use crate::FontResolver;
 use crate::{ImageHrefResolver, ImageRendering, ShapeRendering, Size, TextRendering};
 
+/// The color scheme preference for resolving CSS `light-dark()` function.
+///
+/// The CSS `light-dark()` function allows specifying two color values where the first
+/// is for light mode and the second is for dark mode. This option controls which
+/// value is extracted.
+///
+/// This is useful for rendering SVGs exported from applications like Draw.io that
+/// use `light-dark()` for dark mode support.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ColorScheme {
+    /// Use the first value (light mode color). This is the default.
+    #[default]
+    Light,
+    /// Use the second value (dark mode color).
+    Dark,
+}
+
 /// Processing options.
 #[derive(Debug)]
 pub struct Options<'a> {
@@ -98,6 +115,11 @@ pub struct Options<'a> {
     /// A CSS stylesheet that should be injected into the SVG. Can be used to overwrite
     /// certain attributes.
     pub style_sheet: Option<String>,
+
+    /// The color scheme to use when resolving CSS `light-dark()` function.
+    ///
+    /// Default: `ColorScheme::Light`
+    pub color_scheme: ColorScheme,
 }
 
 impl Default for Options<'_> {
@@ -119,6 +141,7 @@ impl Default for Options<'_> {
             #[cfg(feature = "text")]
             fontdb: Arc::new(fontdb::Database::new()),
             style_sheet: None,
+            color_scheme: ColorScheme::default(),
         }
     }
 }

--- a/crates/usvg/src/parser/svgtree/parse.rs
+++ b/crates/usvg/src/parser/svgtree/parse.rs
@@ -15,6 +15,7 @@ const XML_NAMESPACE_NS: &str = "http://www.w3.org/XML/1998/namespace";
 
 use crate::ColorScheme;
 
+// TODO: Use svgtypes::resolve_light_dark once https://github.com/linebender/svgtypes/pull/59 is merged
 /// Resolves CSS `light-dark(value1, value2)` function based on the specified color scheme.
 ///
 /// The `light-dark()` CSS function is used for dark mode support. This function extracts

--- a/crates/usvg/src/parser/svgtree/text.rs
+++ b/crates/usvg/src/parser/svgtree/text.rs
@@ -6,6 +6,7 @@
 use roxmltree::Error;
 
 use super::{AId, Document, EId, NodeId, NodeKind, SvgNode};
+use crate::ColorScheme;
 
 const XLINK_NS: &str = "http://www.w3.org/1999/xlink";
 
@@ -14,6 +15,7 @@ pub(crate) fn parse_svg_text_element<'input>(
     parent_id: NodeId,
     style_sheet: &simplecss::StyleSheet,
     doc: &mut Document<'input>,
+    color_scheme: ColorScheme,
 ) -> Result<(), Error> {
     debug_assert_eq!(parent.tag_name().name(), "text");
 
@@ -31,7 +33,7 @@ pub(crate) fn parse_svg_text_element<'input>(
         }
     };
 
-    parse_svg_text_element_impl(parent, parent_id, style_sheet, space, doc)?;
+    parse_svg_text_element_impl(parent, parent_id, style_sheet, space, doc, color_scheme)?;
 
     trim_text_nodes(parent_id, space, doc);
     Ok(())
@@ -43,6 +45,7 @@ fn parse_svg_text_element_impl<'input>(
     style_sheet: &simplecss::StyleSheet,
     space: XmlSpace,
     doc: &mut Document<'input>,
+    color_scheme: ColorScheme,
 ) -> Result<(), Error> {
     for node in parent.children() {
         if node.is_text() {
@@ -77,8 +80,15 @@ fn parse_svg_text_element_impl<'input>(
             is_tref = true;
         }
 
-        let node_id =
-            super::parse::parse_svg_element(node, parent_id, tag_name, style_sheet, false, doc)?;
+        let node_id = super::parse::parse_svg_element(
+            node,
+            parent_id,
+            tag_name,
+            style_sheet,
+            false,
+            doc,
+            color_scheme,
+        )?;
         let space = get_xmlspace(doc, node_id, space);
 
         if is_tref {
@@ -93,7 +103,7 @@ fn parse_svg_text_element_impl<'input>(
                 }
             }
         } else {
-            parse_svg_text_element_impl(node, node_id, style_sheet, space, doc)?;
+            parse_svg_text_element_impl(node, node_id, style_sheet, space, doc, color_scheme)?;
         }
     }
 

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -547,3 +547,52 @@ fn no_text_nodes() {
     let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
     assert!(!tree.has_text_nodes());
 }
+
+/// Tests that the CSS `light-dark()` function is correctly parsed.
+/// Draw.io exports SVGs with `light-dark()` for dark mode support.
+/// usvg should extract the first (light-mode) value.
+#[test]
+fn light_dark_css_function() {
+    // Test with simple color values
+    let svg = r#"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+        <rect id='rect1' x='10' y='10' width='80' height='80'
+              style='fill: light-dark(red, blue)'/>
+    </svg>"#;
+
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    let usvg::Node::Path(ref path) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+
+    // Should extract "red" (the first/light-mode value)
+    assert_eq!(
+        path.fill().unwrap().paint(),
+        &usvg::Paint::Color(Color::new_rgb(255, 0, 0))
+    );
+}
+
+/// Tests that `light-dark()` with rgb() function arguments is correctly parsed.
+#[test]
+fn light_dark_css_function_with_rgb() {
+    let svg = r#"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 121 61'>
+        <g fill='black' font-family='Helvetica' text-anchor='middle' font-size='12px'
+           style='fill: light-dark(rgb(0, 128, 0), rgb(255, 255, 255));'>
+            <rect x='10' y='10' width='80' height='40'/>
+        </g>
+    </svg>"#;
+
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+
+    let usvg::Node::Group(ref group) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+    let usvg::Node::Path(ref path) = &group.children()[0] else {
+        unreachable!()
+    };
+
+    // Should extract rgb(0, 128, 0) which is green
+    assert_eq!(
+        path.fill().unwrap().paint(),
+        &usvg::Paint::Color(Color::new_rgb(0, 128, 0))
+    );
+}

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -596,3 +596,64 @@ fn light_dark_css_function_with_rgb() {
         &usvg::Paint::Color(Color::new_rgb(0, 128, 0))
     );
 }
+
+#[test]
+fn light_dark_css_function_with_dark_scheme() {
+    use usvg::Color;
+
+    let svg = r#"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+        <g style='fill: light-dark(red, blue)'>
+            <rect x='10' y='10' width='80' height='40'/>
+        </g>
+    </svg>"#;
+
+    let opt = usvg::Options {
+        color_scheme: usvg::ColorScheme::Dark,
+        ..Default::default()
+    };
+    let tree = usvg::Tree::from_str(&svg, &opt).unwrap();
+
+    let usvg::Node::Group(ref group) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+    let usvg::Node::Path(ref path) = &group.children()[0] else {
+        unreachable!()
+    };
+
+    // With Dark scheme, should extract the second value (blue)
+    assert_eq!(
+        path.fill().unwrap().paint(),
+        &usvg::Paint::Color(Color::new_rgb(0, 0, 255))
+    );
+}
+
+/// Regression test: Tree::from_data_nested should inherit color_scheme from parent Options.
+/// This is used when resolving <image href="..."> that reference other SVG files.
+#[test]
+fn nested_svg_inherits_color_scheme() {
+    use usvg::Color;
+
+    // A nested SVG using light-dark() - this would be embedded via <image href="data:...">
+    let nested_svg = br#"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'>
+        <rect style='fill: light-dark(red, blue)' width='100' height='100'/>
+    </svg>"#;
+
+    // Test with Dark color scheme
+    let opt = usvg::Options {
+        color_scheme: usvg::ColorScheme::Dark,
+        ..Default::default()
+    };
+
+    // from_data_nested should inherit color_scheme from opt
+    let tree = usvg::Tree::from_data_nested(nested_svg, &opt).unwrap();
+
+    let usvg::Node::Path(ref path) = &tree.root().children()[0] else {
+        unreachable!()
+    };
+
+    // With Dark scheme inherited, should extract blue (the second value)
+    assert_eq!(
+        path.fill().unwrap().paint(),
+        &usvg::Paint::Color(Color::new_rgb(0, 0, 255))
+    );
+}


### PR DESCRIPTION
Closes [#900](https://github.com/linebender/resvg/issues/900)

Added support for the CSS `light-dark()` function to handle SVGs exported from Draw.io with dark mode support. Previously, usvg failed to parse `light-dark()` and fell back to black, making text invisible on dark backgrounds.

Already tested in Zed
