### PR TITLE
Don't emit warning when encountering link with `none`

### DIFF
--- a/crates/usvg/src/parser/svgtree/mod.rs
+++ b/crates/usvg/src/parser/svgtree/mod.rs
@@ -282,7 +282,7 @@ impl<'a, 'input: 'a> SvgNode<'a, 'input> {
             .iter()
             .find(|a| a.name == aid)
             .map(|a| a.value.as_str())?;
-        // These AId have a initial value of none
+        // These AId have an initial value of none
         let is_possible_none = matches!(
             aid,
             AId::Mask


### PR DESCRIPTION
Potential fix for https://github.com/linebender/resvg/issues/993