### PR TITLE
feat(usvg): add warning when parsing malformed paths

### DIFF
--- a/crates/usvg/src/parser/shapes.rs
+++ b/crates/usvg/src/parser/shapes.rs
@@ -31,8 +31,8 @@ pub(crate) fn convert_path(node: SvgNode) -> Option<Arc<Path>> {
             Ok(v) => v,
             Err(e) => {
                 log::warn!("Error during path parsing: {e}");
-                break
-            },
+                break;
+            }
         };
 
         match segment {

--- a/crates/usvg/src/parser/shapes.rs
+++ b/crates/usvg/src/parser/shapes.rs
@@ -29,7 +29,10 @@ pub(crate) fn convert_path(node: SvgNode) -> Option<Arc<Path>> {
     for segment in svgtypes::SimplifyingPathParser::from(value) {
         let segment = match segment {
             Ok(v) => v,
-            Err(_) => break,
+            Err(e) => {
+                log::warn!("Error during path parsing: {e}");
+                break
+            },
         };
 
         match segment {

--- a/crates/usvg/src/parser/svgtree/mod.rs
+++ b/crates/usvg/src/parser/svgtree/mod.rs
@@ -888,7 +888,10 @@ impl<'a, 'input: 'a> FromValue<'a, 'input> for Transform {
     fn parse(_: SvgNode, _: AId, value: &str) -> Option<Self> {
         let ts = match svgtypes::Transform::from_str(value) {
             Ok(v) => v,
-            Err(_) => return None,
+            Err(e) => {
+                log::warn!("Error parsing the transform: {e}");
+                return None;
+            },
         };
 
         let ts = Transform::from_row(

--- a/crates/usvg/src/parser/svgtree/mod.rs
+++ b/crates/usvg/src/parser/svgtree/mod.rs
@@ -891,7 +891,7 @@ impl<'a, 'input: 'a> FromValue<'a, 'input> for Transform {
             Err(e) => {
                 log::warn!("Error parsing the transform: {e}");
                 return None;
-            },
+            }
         };
 
         let ts = Transform::from_row(

--- a/crates/usvg/src/parser/svgtree/mod.rs
+++ b/crates/usvg/src/parser/svgtree/mod.rs
@@ -888,10 +888,7 @@ impl<'a, 'input: 'a> FromValue<'a, 'input> for Transform {
     fn parse(_: SvgNode, _: AId, value: &str) -> Option<Self> {
         let ts = match svgtypes::Transform::from_str(value) {
             Ok(v) => v,
-            Err(e) => {
-                log::warn!("Error parsing the transform: {e}");
-                return None;
-            }
+            Err(_) => return None,
         };
 
         let ts = Transform::from_row(


### PR DESCRIPTION
Linked to https://github.com/linebender/resvg/issues/938

```sh
$ cargo run --package usvg a.svg b.svg

Warning (in usvg::parser::shapes:33): Error during path parsing: invalid number at position 9
```