### PR TITLE
Version bump from 0.46.0 to 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,18 @@ This changelog also contains important changes in dependencies.
 
 ## [Unreleased]
 
-- This release has an MSRV of 1.87.0 for `usvg` and `resvg` and the C API.
-- Focal radius supported for Radial Gradients. (#1014 by @wmedrano)
+This release has an MSRV of 1.87.0 for `usvg` and `resvg` and the C API.
+
+## [0.47.0] 2026-02-05
+
+This release has an MSRV of 1.87.0 for `usvg` and `resvg` and the C API.
+
+### Added
+- Focal radius (`fr`) supported for Radial Gradients. (#1014 by @wmedrano)
+- Support for variable fonts based on font-variation-settings CSS property. (#997 by @oetiker)
+
+### Changed
+- `tiny-skia` has a major version bump from 0.11 to 0.12.
 
 ## [0.46.0]
 
@@ -1330,7 +1340,8 @@ This release has an MSRV of 1.65 for `usvg` and 1.67.1 for `resvg` and the C API
 
 [#897]: https://github.com/linebender/resvg/pull/897
 
-[Unreleased]: https://github.com/linebender/resvg/compare/v0.46.0...HEAD
+[Unreleased]: https://github.com/linebender/resvg/compare/v0.47.0...HEAD
+[0.47.0]: https://github.com/linebender/resvg/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/linebender/resvg/compare/v0.45.1...v0.46.0
 [0.45.1]: https://github.com/linebender/resvg/compare/v0.45.0...v0.45.1
 [0.45.0]: https://github.com/linebender/resvg/compare/v0.44.0...v0.45.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "resvg"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "gif",
  "image-webp",
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "resvg-capi"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "log",
  "resvg",
@@ -676,7 +676,7 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "base64",
  "data-url",

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resvg-capi"
-version = "0.46.0"
+version = "0.47.0"
 keywords = ["svg", "render", "raster", "c-api"]
 license.workspace = true
 edition = "2024"

--- a/crates/c-api/ResvgQt.h
+++ b/crates/c-api/ResvgQt.h
@@ -11,9 +11,9 @@
 #define RESVG_QT_H
 
 #define RESVG_QT_MAJOR_VERSION 0
-#define RESVG_QT_MINOR_VERSION 46
+#define RESVG_QT_MINOR_VERSION 47
 #define RESVG_QT_PATCH_VERSION 0
-#define RESVG_QT_VERSION "0.46.0"
+#define RESVG_QT_VERSION "0.47.0"
 
 #include <cmath>
 

--- a/crates/c-api/resvg.h
+++ b/crates/c-api/resvg.h
@@ -14,9 +14,9 @@
 #include <stdint.h>
 
 #define RESVG_MAJOR_VERSION 0
-#define RESVG_MINOR_VERSION 46
+#define RESVG_MINOR_VERSION 47
 #define RESVG_PATCH_VERSION 0
-#define RESVG_VERSION "0.46.0"
+#define RESVG_VERSION "0.47.0"
 
 /**
  * @brief List of possible errors.

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resvg"
-version = "0.46.0"
+version = "0.47.0"
 keywords = ["svg", "render", "raster"]
 license.workspace = true
 edition = "2024"
@@ -22,7 +22,7 @@ pico-args = { version = "0.5", features = ["eq-separator"] }
 rgb = "0.8"
 svgtypes = "0.16.1"
 tiny-skia = "0.12.0"
-usvg = { path = "../usvg", version = "0.46.0", default-features = false }
+usvg = { path = "../usvg", version = "0.47.0", default-features = false }
 zune-jpeg = { version = "0.5.8", optional = true }
 
 [dev-dependencies]

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "usvg"
-version = "0.46.0"
+version = "0.47.0"
 keywords = ["svg"]
 license.workspace = true
 edition = "2024"

--- a/tools/explorer-thumbnailer/Cargo.toml
+++ b/tools/explorer-thumbnailer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "explorer-thumbnailer"
-version = "0.46.0"
+version = "0.47.0"
 license.workspace = true
 edition = "2021"
 publish = false

--- a/tools/explorer-thumbnailer/install/installer.iss
+++ b/tools/explorer-thumbnailer/install/installer.iss
@@ -1,8 +1,8 @@
 [Setup]
 AppName="resvg Explorer Extension"
-AppVersion="0.46.0"
-VersionInfoVersion="0.0.46.0"
-AppVerName="resvg Explorer Extension 0.46.0"
+AppVersion="0.47.0"
+VersionInfoVersion="0.0.47.0"
+AppVerName="resvg Explorer Extension 0.47.0"
 AppPublisher="The Resvg Authors"
 AppPublisherURL=https://github.com/linebender/resvg
 DefaultDirName="{pf}\resvg Explorer Extension"


### PR DESCRIPTION
- Doing a major version bump since `tiny-skia` was bumped from 0.11 to 0.12
  - `tiny-skia` is re-exported from `resvg` thereby making it part of the public API