### PR TITLE
Don't exclude gitignore file from tarballs

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -72,7 +72,6 @@ jobs:
           cd ..
           env XZ_OPT="-9e" tar \
               --exclude=".git" \
-              --exclude=".gitignore" \
               --exclude="resvg-$VERSION/.github" \
               --exclude="resvg-$VERSION/version-bump.md" \
               --exclude="resvg-$VERSION/docs" \


### PR DESCRIPTION
I think this ought to fix https://github.com/linebender/resvg/issues/1006 but untested
