### PR TITLE
perf: devirtualize light model and hoist loop-invariant values for feSpecularLighting

### DIFF
--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -42,3 +42,7 @@ memmap-fonts = ["usvg/memmap-fonts"]
 # When disabled, `image` elements with SVG data will still be rendered.
 # Adds around 200KiB to your binary.
 raster-images = ["gif", "image-webp", "dep:zune-jpeg"]
+
+[[bench]]
+name = "specular_lighting_bench"
+harness = false

--- a/crates/resvg/benches/specular_lighting_bench.rs
+++ b/crates/resvg/benches/specular_lighting_bench.rs
@@ -47,13 +47,7 @@ fn main() {
     println!("feSpecularLighting Benchmark — Real-World Usage Patterns");
     println!("=========================================================\n");
 
-    let resolutions: &[(u32, u32)] = &[
-        (24, 24),
-        (48, 48),
-        (96, 96),
-        (200, 150),
-        (400, 300),
-    ];
+    let resolutions: &[(u32, u32)] = &[(24, 24), (48, 48), (96, 96), (200, 150), (400, 300)];
     let exponents: &[f32] = &[1.0, 5.0, 12.0, 20.0, 128.0];
     // PointLight listed first as it is the most common light source
     let light_types: &[&str] = &["point", "distant", "spot"];
@@ -68,11 +62,8 @@ fn main() {
         for &light_type in light_types {
             for &exponent in exponents {
                 let svg = make_svg(width, height, exponent, light_type);
-                let tree = resvg::usvg::Tree::from_str(
-                    &svg,
-                    &resvg::usvg::Options::default(),
-                )
-                .unwrap();
+                let tree =
+                    resvg::usvg::Tree::from_str(&svg, &resvg::usvg::Options::default()).unwrap();
 
                 // Warmup
                 for _ in 0..2 {

--- a/crates/resvg/benches/specular_lighting_bench.rs
+++ b/crates/resvg/benches/specular_lighting_bench.rs
@@ -1,30 +1,24 @@
 // Copyright 2020 the Resvg Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! Benchmark for feSpecularLighting filter primitive.
+//! Benchmark for feSpecularLighting filter primitive with real-world usage patterns.
+//!
+//! Covers the 3D-button size range with MDN canonical parameters.
+//! PointLight is the primary (most common) light source.
 //!
 //! Run with: cargo bench --bench specular_lighting_bench -p resvg
 
+use std::hint::black_box;
 use std::time::Instant;
 
 fn make_svg(width: u32, height: u32, exponent: f32, light_type: &str) -> String {
     let light_element = match light_type {
         "distant" => r#"<feDistantLight azimuth="45" elevation="45"/>"#.to_string(),
         "point" => {
-            format!(
-                r#"<fePointLight x="{}" y="{}" z="100"/>"#,
-                width / 2,
-                height / 2
-            )
+            r#"<fePointLight x="50" y="100" z="200"/>"#.to_string()
         }
         "spot" => {
-            format!(
-                r#"<feSpotLight x="{}" y="{}" z="100" pointsAtX="{}" pointsAtY="{}" pointsAtZ="0"/>"#,
-                width / 2,
-                height / 2,
-                width,
-                height
-            )
+            r#"<feSpotLight x="50" y="100" z="200" pointsAtX="100" pointsAtY="100" pointsAtZ="0" specularExponent="8" limitingConeAngle="30"/>"#.to_string()
         }
         _ => unreachable!(),
     };
@@ -33,8 +27,8 @@ fn make_svg(width: u32, height: u32, exponent: f32, light_type: &str) -> String 
         r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
   <defs>
     <filter id="f">
-      <feSpecularLighting in="SourceGraphic" surfaceScale="1"
-        specularConstant="1" specularExponent="{exp}"
+      <feSpecularLighting in="SourceGraphic" surfaceScale="5"
+        specularConstant="0.75" specularExponent="{exp}"
         lighting-color="white">
         {light}
       </feSpecularLighting>
@@ -49,81 +43,85 @@ fn make_svg(width: u32, height: u32, exponent: f32, light_type: &str) -> String 
     )
 }
 
-fn bench_one(
-    label: &str,
-    svg_str: &str,
-    warmup_iters: u32,
-    bench_iters: u32,
-    width: u32,
-    height: u32,
-) {
-    let tree = resvg::usvg::Tree::from_str(svg_str, &resvg::usvg::Options::default()).unwrap();
+fn main() {
+    println!("feSpecularLighting Benchmark — Real-World Usage Patterns");
+    println!("=========================================================\n");
 
-    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap();
-
-    // warmup
-    for _ in 0..warmup_iters {
-        pixmap.fill(resvg::tiny_skia::Color::TRANSPARENT);
-        resvg::render(
-            &tree,
-            resvg::tiny_skia::Transform::identity(),
-            &mut pixmap.as_mut(),
-        );
-    }
-
-    // benchmark
-    let start = Instant::now();
-    for _ in 0..bench_iters {
-        pixmap.fill(resvg::tiny_skia::Color::TRANSPARENT);
-        resvg::render(
-            &tree,
-            resvg::tiny_skia::Transform::identity(),
-            &mut pixmap.as_mut(),
-        );
-    }
-    let elapsed = start.elapsed();
-
-    let per_iter = elapsed / bench_iters;
-    let pixels = (width as u64) * (height as u64);
-    let mpixels_per_sec =
-        (pixels as f64 * bench_iters as f64) / elapsed.as_secs_f64() / 1_000_000.0;
+    let resolutions: &[(u32, u32)] = &[
+        (24, 24),
+        (48, 48),
+        (96, 96),
+        (200, 150),
+        (400, 300),
+    ];
+    let exponents: &[f32] = &[1.0, 5.0, 12.0, 20.0, 128.0];
+    // PointLight listed first as it is the most common light source
+    let light_types: &[&str] = &["point", "distant", "spot"];
 
     println!(
-        "{:<60} {:>10.3} ms/iter  ({:.1} Mpx/s)",
-        label,
-        per_iter.as_secs_f64() * 1000.0,
-        mpixels_per_sec,
+        "{:<12} {:<10} {:<10} {:<12} {:<14} {:<10}",
+        "Resolution", "Light", "Exponent", "Time (ms)", "Mpix/s", "Iters"
     );
-}
-
-fn main() {
-    let resolutions: &[(u32, u32)] = &[(64, 64), (256, 256), (1024, 1024), (4096, 4096)];
-    let exponents: &[f32] = &[1.0, 5.0, 20.0, 128.0];
-    let light_types: &[&str] = &["distant", "point", "spot"];
-
-    println!("feSpecularLighting Benchmark");
-    println!("============================");
-    println!();
+    println!("{}", "-".repeat(70));
 
     for &(width, height) in resolutions {
-        println!("--- Resolution: {}x{} ---", width, height);
-
-        let (warmup, iters) = if width <= 256 {
-            (10, 100)
-        } else if width <= 1024 {
-            (3, 20)
-        } else {
-            (1, 5)
-        };
-
-        for &exponent in exponents {
-            for &light_type in light_types {
+        for &light_type in light_types {
+            for &exponent in exponents {
                 let svg = make_svg(width, height, exponent, light_type);
-                let label = format!(
-                    "specular exp={:<5} light={:<8} {}x{}",
-                    exponent, light_type, width, height
+                let tree = resvg::usvg::Tree::from_str(
+                    &svg,
+                    &resvg::usvg::Options::default(),
+                )
+                .unwrap();
+
+                // Warmup
+                for _ in 0..2 {
+                    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap();
+                    resvg::render(
+                        &tree,
+                        resvg::tiny_skia::Transform::identity(),
+                        &mut pixmap.as_mut(),
+                    );
+                }
+
+                // Dynamic iteration count: target ~2 seconds per measurement
+                let probe_start = Instant::now();
+                {
+                    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap();
+                    resvg::render(
+                        &tree,
+                        resvg::tiny_skia::Transform::identity(),
+                        &mut pixmap.as_mut(),
+                    );
+                }
+                let probe_ms = probe_start.elapsed().as_secs_f64() * 1000.0;
+                let iterations = ((2000.0 / probe_ms).ceil() as u32).max(2).min(2000);
+
+                let start = Instant::now();
+                for _ in 0..iterations {
+                    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap();
+                    resvg::render(
+                        &tree,
+                        resvg::tiny_skia::Transform::identity(),
+                        &mut pixmap.as_mut(),
+                    );
+                    black_box(&pixmap);
+                }
+                let elapsed = start.elapsed();
+
+                let ms_per_iter = elapsed.as_secs_f64() * 1000.0 / iterations as f64;
+                let pixels = width as f64 * height as f64;
+                let mpix_per_sec = pixels / (ms_per_iter / 1000.0) / 1_000_000.0;
+
+                println!(
+                    "{:<12} {:<10} {:<10} {:<12.3} {:<14.2} {:<10}",
+                    format!("{}x{}", width, height),
+                    light_type,
+                    exponent,
+                    ms_per_iter,
+                    mpix_per_sec,
+                    iterations
                 );
-                bench_one(&label, &svg, warmup, iters, width, height);
             }
         }
         println!();

--- a/crates/resvg/benches/specular_lighting_bench.rs
+++ b/crates/resvg/benches/specular_lighting_bench.rs
@@ -1,0 +1,131 @@
+// Copyright 2020 the Resvg Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Benchmark for feSpecularLighting filter primitive.
+//!
+//! Run with: cargo bench --bench specular_lighting_bench -p resvg
+
+use std::time::Instant;
+
+fn make_svg(width: u32, height: u32, exponent: f32, light_type: &str) -> String {
+    let light_element = match light_type {
+        "distant" => r#"<feDistantLight azimuth="45" elevation="45"/>"#.to_string(),
+        "point" => {
+            format!(
+                r#"<fePointLight x="{}" y="{}" z="100"/>"#,
+                width / 2,
+                height / 2
+            )
+        }
+        "spot" => {
+            format!(
+                r#"<feSpotLight x="{}" y="{}" z="100" pointsAtX="{}" pointsAtY="{}" pointsAtZ="0"/>"#,
+                width / 2,
+                height / 2,
+                width,
+                height
+            )
+        }
+        _ => unreachable!(),
+    };
+
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
+  <defs>
+    <filter id="f">
+      <feSpecularLighting in="SourceGraphic" surfaceScale="1"
+        specularConstant="1" specularExponent="{exp}"
+        lighting-color="white">
+        {light}
+      </feSpecularLighting>
+    </filter>
+  </defs>
+  <rect width="{w}" height="{h}" fill="gray" filter="url(#f)"/>
+</svg>"##,
+        w = width,
+        h = height,
+        exp = exponent,
+        light = light_element,
+    )
+}
+
+fn bench_one(
+    label: &str,
+    svg_str: &str,
+    warmup_iters: u32,
+    bench_iters: u32,
+    width: u32,
+    height: u32,
+) {
+    let tree = resvg::usvg::Tree::from_str(svg_str, &resvg::usvg::Options::default()).unwrap();
+
+    let mut pixmap = resvg::tiny_skia::Pixmap::new(width, height).unwrap();
+
+    // warmup
+    for _ in 0..warmup_iters {
+        pixmap.fill(resvg::tiny_skia::Color::TRANSPARENT);
+        resvg::render(
+            &tree,
+            resvg::tiny_skia::Transform::identity(),
+            &mut pixmap.as_mut(),
+        );
+    }
+
+    // benchmark
+    let start = Instant::now();
+    for _ in 0..bench_iters {
+        pixmap.fill(resvg::tiny_skia::Color::TRANSPARENT);
+        resvg::render(
+            &tree,
+            resvg::tiny_skia::Transform::identity(),
+            &mut pixmap.as_mut(),
+        );
+    }
+    let elapsed = start.elapsed();
+
+    let per_iter = elapsed / bench_iters;
+    let pixels = (width as u64) * (height as u64);
+    let mpixels_per_sec =
+        (pixels as f64 * bench_iters as f64) / elapsed.as_secs_f64() / 1_000_000.0;
+
+    println!(
+        "{:<60} {:>10.3} ms/iter  ({:.1} Mpx/s)",
+        label,
+        per_iter.as_secs_f64() * 1000.0,
+        mpixels_per_sec,
+    );
+}
+
+fn main() {
+    let resolutions: &[(u32, u32)] = &[(64, 64), (256, 256), (1024, 1024), (4096, 4096)];
+    let exponents: &[f32] = &[1.0, 5.0, 20.0, 128.0];
+    let light_types: &[&str] = &["distant", "point", "spot"];
+
+    println!("feSpecularLighting Benchmark");
+    println!("============================");
+    println!();
+
+    for &(width, height) in resolutions {
+        println!("--- Resolution: {}x{} ---", width, height);
+
+        let (warmup, iters) = if width <= 256 {
+            (10, 100)
+        } else if width <= 1024 {
+            (3, 20)
+        } else {
+            (1, 5)
+        };
+
+        for &exponent in exponents {
+            for &light_type in light_types {
+                let svg = make_svg(width, height, exponent, light_type);
+                let label = format!(
+                    "specular exp={:<5} light={:<8} {}x{}",
+                    exponent, light_type, width, height
+                );
+                bench_one(&label, &svg, warmup, iters, width, height);
+            }
+        }
+        println!();
+    }
+}

--- a/crates/resvg/examples/bench_e2e.rs
+++ b/crates/resvg/examples/bench_e2e.rs
@@ -1,0 +1,1024 @@
+// Copyright 2020 the Resvg Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! End-to-end benchmark for SVG filter optimizations.
+//!
+//! Renders programmatically-generated SVGs (realistic filter scenarios) and
+//! existing filter test SVGs at multiple resolutions, measuring wall-clock time.
+//! Supports sequential (--threads 1) or parallel (--threads N) execution.
+//!
+//! **Modes:**
+//! - Default: run benchmark, output TSV to stdout
+//! - `--compare <baseline.tsv>`: run benchmark and compare against a baseline file
+//! - `--output-tsv <file>`: save TSV output to file instead of stdout
+//! - `--threads N`: use N threads (default: 1 for sequential, noise-free measurement)
+//!
+//! Usage:
+//!   cargo run --release --example bench_e2e -- --output-tsv /tmp/baseline.tsv
+//!   cargo run --release --example bench_e2e -- --compare /tmp/baseline.tsv
+
+use std::collections::{HashMap, HashSet};
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+// ---------------------------------------------------------------------------
+// Configuration (defaults, overridable via CLI)
+// ---------------------------------------------------------------------------
+
+/// Representative resolutions (width, height).
+const RESOLUTIONS: &[(u32, u32)] = &[
+    (16, 16),
+    (20, 20),
+    (24, 24),
+    (48, 48),
+    (96, 96),
+    (200, 150),
+    (400, 300),
+    (600, 400),
+    (800, 600),
+    (1024, 768),
+    (1500, 1000),
+];
+
+/// Resolution-scaled iteration count. Larger images require fewer iterations
+/// to amortise warmup cost while still suppressing sub-percent noise.
+fn iters_for_resolution(w: u32, h: u32) -> usize {
+    let max_dim = w.max(h);
+    match max_dim {
+        0..=49 => 2000,
+        50..=99 => 1000,
+        100..=499 => 300,
+        _ => 100,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Data types
+// ---------------------------------------------------------------------------
+
+struct TestCase {
+    name: String,
+    width: u32,
+    height: u32,
+    svg: String,
+}
+
+struct BenchResult {
+    name: String,
+    resolution: String,
+    median_ms: f64,
+}
+
+// ---------------------------------------------------------------------------
+// SVG generation helpers
+// ---------------------------------------------------------------------------
+
+fn svg_wrap(width: u32, height: u32, filter_defs: &str, body: &str) -> String {
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">
+  <defs>{filter_defs}</defs>
+  {body}
+</svg>"##,
+    )
+}
+
+fn rect_with_filter(width: u32, height: u32, filter_id: &str) -> String {
+    format!(
+        r#"<rect x="0" y="0" width="{width}" height="{height}" fill="seagreen" filter="url(#{filter_id})"/>"#,
+    )
+}
+
+fn two_rects_with_filter(width: u32, height: u32, filter_id: &str) -> String {
+    format!(
+        r#"<rect x="0" y="0" width="{width}" height="{height}" fill="seagreen" filter="url(#{filter_id})"/>
+<rect x="{}" y="{}" width="{}" height="{}" fill="coral" filter="url(#{filter_id})"/>"#,
+        width / 4,
+        height / 4,
+        width / 2,
+        height / 2,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Test case generators: Single-filter scenarios
+// ---------------------------------------------------------------------------
+
+fn gen_drop_shadow(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="4" result="blur"/>
+      <feOffset in="blur" dx="1" dy="1" result="offset"/>
+      <feComposite in="SourceGraphic" in2="offset" operator="over"/>
+    </filter>"#;
+    TestCase {
+        name: "drop-shadow".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_soft_blur(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur stdDeviation="4"/>
+    </filter>"#;
+    TestCase {
+        name: "soft-blur".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+
+fn gen_backdrop_blur(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur stdDeviation="16"/>
+    </filter>"#;
+    TestCase {
+        name: "backdrop-blur".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_color_desaturate(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feColorMatrix type="saturate" values="0.3"/>
+    </filter>"#;
+    TestCase {
+        name: "color-desaturate".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_hue_rotate(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feColorMatrix type="hueRotate" values="90"/>
+    </filter>"#;
+    TestCase {
+        name: "hue-rotate".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_gamma_correct(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feComponentTransfer>
+        <feFuncR type="gamma" amplitude="1" exponent="0.45" offset="0"/>
+        <feFuncG type="gamma" amplitude="1" exponent="0.45" offset="0"/>
+        <feFuncB type="gamma" amplitude="1" exponent="0.45" offset="0"/>
+      </feComponentTransfer>
+    </filter>"#;
+    TestCase {
+        name: "gamma-correct".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_sharpen(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feConvolveMatrix order="3" kernelMatrix="0 -1 0 -1 5 -1 0 -1 0"/>
+    </filter>"#;
+    TestCase {
+        name: "sharpen".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_noise_fill(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feTurbulence type="fractalNoise" baseFrequency="0.05" numOctaves="2"/>
+    </filter>"#;
+    TestCase {
+        name: "noise-fill".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_text_outline(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feMorphology operator="dilate" radius="2" in="SourceGraphic" result="dilated"/>
+      <feComposite in="dilated" in2="SourceGraphic" operator="out"/>
+    </filter>"#;
+    TestCase {
+        name: "text-outline".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_erode(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feMorphology operator="erode" radius="1"/>
+    </filter>"#;
+    TestCase {
+        name: "erode".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_arithmetic_blend(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feFlood flood-color="coral" flood-opacity="0.5" result="flood"/>
+      <feComposite in="SourceGraphic" in2="flood" operator="arithmetic" k1="0" k2="0.5" k3="0.5" k4="0"/>
+    </filter>"#;
+    TestCase {
+        name: "arithmetic-blend".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test case generators: Combination filter scenarios
+// ---------------------------------------------------------------------------
+
+fn gen_3d_button(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feDiffuseLighting in="blur" surfaceScale="5" diffuseConstant="0.75" lighting-color="white" result="diffuse">
+        <feDistantLight azimuth="45" elevation="55"/>
+      </feDiffuseLighting>
+      <feSpecularLighting in="blur" surfaceScale="5" specularConstant="0.5" specularExponent="10" lighting-color="white" result="specular">
+        <feDistantLight azimuth="45" elevation="55"/>
+      </feSpecularLighting>
+      <feComposite in="diffuse" in2="SourceGraphic" operator="in" result="lit"/>
+      <feComposite in="specular" in2="lit" operator="over"/>
+    </filter>"#;
+    TestCase {
+        name: "3d-button".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_icon_glow(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="3" result="blur"/>
+      <feComposite in="blur" in2="SourceGraphic" operator="arithmetic" k1="0" k2="1" k3="0.8" k4="0" result="glow"/>
+      <feMerge>
+        <feMergeNode in="glow"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>"#;
+    TestCase {
+        name: "icon-glow".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_inner_shadow(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+      <feOffset in="blur" dx="2" dy="2" result="offset"/>
+      <feComposite in="offset" in2="SourceGraphic" operator="in" result="shadow"/>
+      <feMerge>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="shadow"/>
+      </feMerge>
+    </filter>"#;
+    TestCase {
+        name: "inner-shadow".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_card_ui(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feColorMatrix type="saturate" values="1.2" result="saturated"/>
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="shadow-blur"/>
+      <feOffset in="shadow-blur" dx="2" dy="2" result="shadow"/>
+      <feMerge>
+        <feMergeNode in="shadow"/>
+        <feMergeNode in="saturated"/>
+      </feMerge>
+    </filter>"#;
+    TestCase {
+        name: "card-ui".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &two_rects_with_filter(w, h, "f")),
+    }
+}
+
+fn gen_emboss_text(w: u32, h: u32) -> TestCase {
+    let filter = r#"
+    <filter id="f">
+      <feConvolveMatrix order="3" kernelMatrix="-2 -1 0 -1 1 1 0 1 2" divisor="1" result="emboss"/>
+      <feComposite in="emboss" in2="SourceGraphic" operator="in"/>
+    </filter>"#;
+    TestCase {
+        name: "emboss-text".into(),
+        width: w,
+        height: h,
+        svg: svg_wrap(w, h, filter, &rect_with_filter(w, h, "f")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution range for each scenario
+// ---------------------------------------------------------------------------
+
+/// Returns the indices into RESOLUTIONS that are applicable for this scenario.
+fn applicable_resolutions(name: &str) -> Vec<usize> {
+    let res = RESOLUTIONS;
+    match name {
+        // 16-1500 (all sizes - most common filter)
+        "drop-shadow" => (0..res.len()).collect(),
+        // 200-1500 (small blur is pointless)
+        "soft-blur" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-1500 (iOS frosted glass)
+        "backdrop-blur" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200)
+            .map(|(i, _)| i)
+            .collect(),
+        // 16-1500 (all sizes - icons hover gray)
+        "color-desaturate" => (0..res.len()).collect(),
+        // 16-1024 (icons to laptop)
+        "hue-rotate" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w <= 1024)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-1024 (applied to images not icons)
+        "gamma-correct" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200 && *w <= 1024)
+            .map(|(i, _)| i)
+            .collect(),
+        // 400-1500 (sharpen on large images)
+        "sharpen" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 400)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-1024 (texture generation)
+        "noise-fill" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200 && *w <= 1024)
+            .map(|(i, _)| i)
+            .collect(),
+        // 16-400 (text/icon elements)
+        "text-outline" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w <= 400)
+            .map(|(i, _)| i)
+            .collect(),
+        // 16-600 (small to medium elements)
+        "erode" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w <= 600)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-1024 (medium range)
+        "arithmetic-blend" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200 && *w <= 1024)
+            .map(|(i, _)| i)
+            .collect(),
+        // 24-400 (small buttons to medium)
+        "3d-button" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 24 && *w <= 400)
+            .map(|(i, _)| i)
+            .collect(),
+        // 16-200 (icons only)
+        "icon-glow" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w <= 200)
+            .map(|(i, _)| i)
+            .collect(),
+        // 24-600 (small to medium UI elements)
+        "inner-shadow" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 24 && *w <= 600)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-800 (card components)
+        "card-ui" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200 && *w <= 800)
+            .map(|(i, _)| i)
+            .collect(),
+        // 200-600 (text regions)
+        "emboss-text" => res
+            .iter()
+            .enumerate()
+            .filter(|(_, (w, _))| *w >= 200 && *w <= 600)
+            .map(|(i, _)| i)
+            .collect(),
+        _ => (0..res.len()).collect(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generate all programmatic test cases
+// ---------------------------------------------------------------------------
+
+fn generate_all_cases() -> Vec<TestCase> {
+    let generators: Vec<(&str, fn(u32, u32) -> TestCase)> = vec![
+        ("drop-shadow", gen_drop_shadow),
+        ("soft-blur", gen_soft_blur),
+        ("backdrop-blur", gen_backdrop_blur),
+        ("color-desaturate", gen_color_desaturate),
+        ("hue-rotate", gen_hue_rotate),
+        ("gamma-correct", gen_gamma_correct),
+        ("sharpen", gen_sharpen),
+        ("noise-fill", gen_noise_fill),
+        ("text-outline", gen_text_outline),
+        ("erode", gen_erode),
+        ("arithmetic-blend", gen_arithmetic_blend),
+        ("3d-button", gen_3d_button),
+        ("icon-glow", gen_icon_glow),
+        ("inner-shadow", gen_inner_shadow),
+        ("card-ui", gen_card_ui),
+        ("emboss-text", gen_emboss_text),
+    ];
+
+    let mut cases = Vec::new();
+    for (name, generator) in &generators {
+        for idx in applicable_resolutions(name) {
+            let (w, h) = RESOLUTIONS[idx];
+            cases.push(generator(w, h));
+        }
+    }
+    cases
+}
+
+// ---------------------------------------------------------------------------
+// Collect existing filter test SVGs
+// ---------------------------------------------------------------------------
+
+fn find_filter_test_dir() -> Option<PathBuf> {
+    // Try relative to the executable location first, then standard paths.
+    let candidates = [
+        PathBuf::from("crates/resvg/tests/tests/filters"),
+        PathBuf::from("tests/tests/filters"),
+    ];
+    // Also try from the manifest directory (running via cargo run)
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").ok();
+    let mut all = candidates.to_vec();
+    if let Some(dir) = &manifest_dir {
+        all.insert(0, PathBuf::from(dir).join("tests/tests/filters"));
+    }
+    all.into_iter().find(|p| p.is_dir())
+}
+
+fn collect_existing_filter_svgs() -> Vec<TestCase> {
+    let filter_dir = match find_filter_test_dir() {
+        Some(d) => d,
+        None => {
+            eprintln!("[warn] Filter test directory not found, skipping existing SVGs");
+            return Vec::new();
+        }
+    };
+
+    let mut cases = Vec::new();
+    let mut svg_paths: Vec<PathBuf> = Vec::new();
+
+    // Walk directories
+    if let Ok(entries) = std::fs::read_dir(&filter_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Ok(files) = std::fs::read_dir(&path) {
+                    for file in files.flatten() {
+                        let fpath = file.path();
+                        if fpath.extension().is_some_and(|e| e == "svg") {
+                            svg_paths.push(fpath);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    svg_paths.sort();
+
+    for svg_path in &svg_paths {
+        let svg_data = match std::fs::read_to_string(svg_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        // Derive a name from path: "feGaussianBlur/simple-case"
+        let rel = svg_path
+            .strip_prefix(&filter_dir)
+            .unwrap_or(svg_path)
+            .with_extension("");
+        let name = format!("existing:{}", rel.display());
+
+        // Parse to get original dimensions
+        let opt = usvg::Options::default();
+        let tree = match usvg::Tree::from_str(&svg_data, &opt) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        let orig_size = tree.size().to_int_size();
+        let ow = orig_size.width().max(1);
+        let oh = orig_size.height().max(1);
+
+        // 1x (original size)
+        cases.push(TestCase {
+            name: format!("{name}@1x"),
+            width: ow,
+            height: oh,
+            svg: svg_data.clone(),
+        });
+
+        // 3x scale
+        cases.push(TestCase {
+            name: format!("{name}@3x"),
+            width: ow * 3,
+            height: oh * 3,
+            svg: svg_data,
+        });
+    }
+
+    cases
+}
+
+// Maximum wall time budget per case (milliseconds). Cases that are intrinsically
+// slower than this per-iteration (e.g. huge-radius morphology) are auto-scaled.
+const MAX_CASE_BUDGET_MS: f64 = 30_000.0; // 30 seconds total per case
+const SKIP_ITER_THRESHOLD_MS: f64 = 10_000.0; // if 1 iter > 10s, skip case
+
+// ---------------------------------------------------------------------------
+// Benchmark execution
+// ---------------------------------------------------------------------------
+
+fn bench_one(case: &TestCase) -> f64 {
+    let opt = usvg::Options::default();
+    let tree = match usvg::Tree::from_str(&case.svg, &opt) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("[warn] Failed to parse SVG for '{}': {}", case.name, e);
+            return -1.0;
+        }
+    };
+
+    let orig_size = tree.size().to_int_size();
+    let sx = case.width as f32 / orig_size.width().max(1) as f32;
+    let sy = case.height as f32 / orig_size.height().max(1) as f32;
+    let transform = tiny_skia::Transform::from_scale(sx, sy);
+
+    let mut pixmap = match tiny_skia::Pixmap::new(case.width, case.height) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "[warn] Failed to create pixmap {}x{} for '{}'",
+                case.width, case.height, case.name
+            );
+            return -1.0;
+        }
+    };
+
+    // Probe: run one iteration to estimate per-iter cost and scale accordingly.
+    pixmap.fill(tiny_skia::Color::TRANSPARENT);
+    let probe_start = Instant::now();
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+    let probe_ms = probe_start.elapsed().as_secs_f64() * 1000.0;
+
+    if probe_ms >= SKIP_ITER_THRESHOLD_MS {
+        // Degenerate case (e.g. huge-radius morphology): skip with probe as result.
+        eprintln!(
+            " [slow:{:.0}ms, skipping extra iters]",
+            probe_ms
+        );
+        return probe_ms;
+    }
+
+    // Scale iteration count to stay within budget, but respect resolution-based minimum.
+    let resolution_iters = iters_for_resolution(case.width, case.height);
+    let budget_iters = if probe_ms > 0.0 {
+        (MAX_CASE_BUDGET_MS / probe_ms) as usize
+    } else {
+        resolution_iters
+    };
+    let bench_iters = resolution_iters.min(budget_iters).max(5);
+    let warmup_iters = (bench_iters / 10).max(2);
+
+    // Warmup (probe already counted as 1)
+    for _ in 1..warmup_iters {
+        pixmap.fill(tiny_skia::Color::TRANSPARENT);
+        resvg::render(&tree, transform, &mut pixmap.as_mut());
+    }
+
+    // Measure
+    let mut times = Vec::with_capacity(bench_iters);
+    for _ in 0..bench_iters {
+        pixmap.fill(tiny_skia::Color::TRANSPARENT);
+        let start = Instant::now();
+        resvg::render(&tree, transform, &mut pixmap.as_mut());
+        times.push(start.elapsed().as_secs_f64() * 1000.0); // ms
+    }
+
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    times[times.len() / 2] // median
+}
+
+fn run_bench(cases: Vec<TestCase>, num_threads: usize) -> Vec<BenchResult> {
+    let total = cases.len();
+    let counter = AtomicUsize::new(0);
+    let cases_ref = &cases;
+    let counter_ref = &counter;
+
+    // Pre-compute the work assignments for each thread
+    let chunks: Vec<Vec<usize>> = {
+        let n = num_threads.max(1);
+        let mut chunks = vec![Vec::new(); n];
+        for (i, _) in cases.iter().enumerate() {
+            chunks[i % n].push(i);
+        }
+        chunks
+    };
+
+    let all_results: Vec<Vec<(usize, BenchResult)>> = std::thread::scope(|s| {
+        let handles: Vec<_> = chunks
+            .into_iter()
+            .map(|indices| {
+                s.spawn(move || {
+                    let mut results = Vec::new();
+                    for idx in indices {
+                        let case = &cases_ref[idx];
+                        let median = bench_one(case);
+                        let done = counter_ref.fetch_add(1, Ordering::Relaxed) + 1;
+                        eprint!("\r[{}/{}] {}", done, total, case.name);
+                        results.push((
+                            idx,
+                            BenchResult {
+                                name: case.name.clone(),
+                                resolution: format!("{}x{}", case.width, case.height),
+                                median_ms: median,
+                            },
+                        ));
+                    }
+                    results
+                })
+            })
+            .collect();
+
+        handles.into_iter().map(|h| h.join().unwrap()).collect()
+    });
+
+    eprintln!();
+
+    // Flatten and sort by original index
+    let mut flat: Vec<(usize, BenchResult)> = all_results.into_iter().flatten().collect();
+    flat.sort_by_key(|(idx, _)| *idx);
+    flat.into_iter().map(|(_, r)| r).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Output & comparison
+// ---------------------------------------------------------------------------
+
+fn write_tsv(results: &[BenchResult], writer: &mut dyn std::io::Write) {
+    writeln!(writer, "name\tresolution\tmedian_ms").unwrap();
+    for r in results {
+        writeln!(writer, "{}\t{}\t{:.3}", r.name, r.resolution, r.median_ms).unwrap();
+    }
+}
+
+fn load_tsv(path: &Path) -> Vec<BenchResult> {
+    let file = std::fs::File::open(path).expect("Failed to open baseline TSV");
+    let reader = std::io::BufReader::new(file);
+    let mut results = Vec::new();
+    for line in reader.lines() {
+        let line = line.unwrap();
+        if line.starts_with("name\t") {
+            continue; // skip header
+        }
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() >= 3 {
+            results.push(BenchResult {
+                name: parts[0].to_string(),
+                resolution: parts[1].to_string(),
+                median_ms: parts[2].parse().unwrap_or(-1.0),
+            });
+        }
+    }
+    results
+}
+
+fn compare_results(baseline: &[BenchResult], optimized: &[BenchResult]) {
+    // Build a lookup: (name, resolution) -> median_ms
+    let baseline_map: HashMap<(&str, &str), f64> = baseline
+        .iter()
+        .map(|r| ((r.name.as_str(), r.resolution.as_str()), r.median_ms))
+        .collect();
+
+    let _optimized_map: HashMap<(&str, &str), f64> = optimized
+        .iter()
+        .map(|r| ((r.name.as_str(), r.resolution.as_str()), r.median_ms))
+        .collect();
+
+    // Separate generated vs existing test cases
+    let mut gen_pairs: Vec<(&str, &str, f64, f64)> = Vec::new();
+    let mut exist_1x_base = 0.0_f64;
+    let mut exist_1x_opt = 0.0_f64;
+    let mut exist_3x_base = 0.0_f64;
+    let mut exist_3x_opt = 0.0_f64;
+    let mut exist_1x_count = 0usize;
+    let mut exist_3x_count = 0usize;
+
+    // Per-filter type stats
+    struct FilterStats {
+        count: usize,
+        speedups: Vec<f64>,
+    }
+    let mut filter_stats: HashMap<String, FilterStats> = HashMap::new();
+
+    let mut regressions: Vec<(String, String, f64, f64)> = Vec::new();
+
+    for r in optimized {
+        let key = (r.name.as_str(), r.resolution.as_str());
+        if let Some(&base_ms) = baseline_map.get(&key) {
+            if base_ms <= 0.0 || r.median_ms <= 0.0 {
+                continue;
+            }
+            let speedup = base_ms / r.median_ms;
+
+            if r.name.starts_with("existing:") {
+                // Extract filter type from path like "existing:feGaussianBlur/simple-case@1x"
+                let inner = r.name.strip_prefix("existing:").unwrap_or(&r.name);
+                let filter_type = inner.split('/').next().unwrap_or("unknown");
+                let entry = filter_stats
+                    .entry(filter_type.to_string())
+                    .or_insert_with(|| FilterStats {
+                        count: 0,
+                        speedups: Vec::new(),
+                    });
+                entry.count += 1;
+                entry.speedups.push(speedup);
+
+                if r.name.ends_with("@1x") {
+                    exist_1x_base += base_ms;
+                    exist_1x_opt += r.median_ms;
+                    exist_1x_count += 1;
+                } else if r.name.ends_with("@3x") {
+                    exist_3x_base += base_ms;
+                    exist_3x_opt += r.median_ms;
+                    exist_3x_count += 1;
+                }
+            } else {
+                gen_pairs.push((&r.name, &r.resolution, base_ms, r.median_ms));
+            }
+
+            if speedup < 0.95 {
+                regressions.push((
+                    r.name.clone(),
+                    r.resolution.clone(),
+                    base_ms,
+                    r.median_ms,
+                ));
+            }
+        }
+    }
+
+    // Print generated scenario comparison
+    eprintln!("\n=== Generated Scenario Performance Comparison ===\n");
+    eprintln!(
+        "{:<22} | {:<12} | {:>14} | {:>14} | {:>8}",
+        "Scenario", "Resolution", "Baseline (ms)", "Optimized (ms)", "Speedup"
+    );
+    eprintln!("{}", "-".repeat(80));
+    for (name, res, base, opt) in &gen_pairs {
+        let speedup = base / opt;
+        eprintln!(
+            "{:<22} | {:<12} | {:>14.3} | {:>14.3} | {:>7.2}x",
+            name, res, base, opt, speedup
+        );
+    }
+
+    // Print existing SVG summary
+    eprintln!("\n=== Existing Test SVGs ({} files, 1x & 3x scale) ===\n", exist_1x_count.max(exist_3x_count));
+    if exist_1x_count > 0 {
+        eprintln!("Total baseline (1x):  {:>10.3} ms", exist_1x_base);
+        eprintln!("Total optimized (1x): {:>10.3} ms", exist_1x_opt);
+        eprintln!(
+            "Overall speedup (1x): {:>10.2}x",
+            if exist_1x_opt > 0.0 {
+                exist_1x_base / exist_1x_opt
+            } else {
+                0.0
+            }
+        );
+    }
+    if exist_3x_count > 0 {
+        eprintln!("Total baseline (3x):  {:>10.3} ms", exist_3x_base);
+        eprintln!("Total optimized (3x): {:>10.3} ms", exist_3x_opt);
+        eprintln!(
+            "Overall speedup (3x): {:>10.2}x",
+            if exist_3x_opt > 0.0 {
+                exist_3x_base / exist_3x_opt
+            } else {
+                0.0
+            }
+        );
+    }
+
+    // Print per-filter summary
+    eprintln!("\n=== Per-Filter Type Summary ===\n");
+    eprintln!(
+        "{:<25} | {:>8} | {:>10} | {:>10}",
+        "Filter", "Tests", "Avg Speed", "Max Speed"
+    );
+    eprintln!("{}", "-".repeat(62));
+    let mut filter_names: Vec<&String> = filter_stats.keys().collect();
+    filter_names.sort();
+    for name in filter_names {
+        let stats = &filter_stats[name];
+        let avg: f64 = stats.speedups.iter().sum::<f64>() / stats.speedups.len() as f64;
+        let max: f64 = stats
+            .speedups
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
+        eprintln!(
+            "{:<25} | {:>8} | {:>9.2}x | {:>9.2}x",
+            name, stats.count, avg, max
+        );
+    }
+
+    // Print regressions
+    eprintln!("\n=== Regressions (optimized >5% slower) ===\n");
+    if regressions.is_empty() {
+        eprintln!("(none)");
+    } else {
+        for (name, res, base, opt) in &regressions {
+            let speedup = base / opt;
+            eprintln!(
+                "{} @ {} : {:.3}ms -> {:.3}ms ({:.2}x)",
+                name, res, base, opt, speedup
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+/// Load a filter set from a TSV file: each line is "name\tresolution".
+fn load_only_filter(path: &Path) -> HashSet<(String, String)> {
+    let file = std::fs::File::open(path).expect("Failed to open --only file");
+    let reader = std::io::BufReader::new(file);
+    let mut set = HashSet::new();
+    for line in reader.lines() {
+        let line = line.unwrap();
+        let parts: Vec<&str> = line.split('\t').collect();
+        if parts.len() >= 2 {
+            set.insert((parts[0].to_string(), parts[1].to_string()));
+        }
+    }
+    set
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Parse CLI arguments
+    let mut compare_path: Option<PathBuf> = None;
+    let mut only_path: Option<PathBuf> = None;
+    let mut output_tsv_path: Option<PathBuf> = None;
+    let mut num_threads: usize = 1;
+
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--compare" => {
+                compare_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "--only" => {
+                only_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "--output-tsv" => {
+                output_tsv_path = Some(PathBuf::from(&args[i + 1]));
+                i += 2;
+            }
+            "--threads" => {
+                num_threads = args[i + 1].parse().expect("Invalid --threads value");
+                i += 2;
+            }
+            _ => {
+                eprintln!("Unknown argument: {}", args[i]);
+                eprintln!(
+                    "Usage: bench_e2e [--compare <baseline.tsv>] [--output-tsv <file>] \
+                     [--only <cases.tsv>] [--threads N]"
+                );
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let only_filter = only_path.as_deref().map(load_only_filter);
+
+    eprintln!("Generating test cases...");
+    let generated = generate_all_cases();
+    eprintln!("  {} generated scenarios", generated.len());
+
+    eprintln!("Collecting existing filter test SVGs...");
+    let existing = collect_existing_filter_svgs();
+    eprintln!("  {} existing test cases (1x + 3x)", existing.len());
+
+    let mut all_cases = generated;
+    all_cases.extend(existing);
+
+    // Apply --only filter if specified
+    if let Some(ref filter_set) = only_filter {
+        let before = all_cases.len();
+        all_cases.retain(|c| {
+            let res = format!("{}x{}", c.width, c.height);
+            filter_set.contains(&(c.name.clone(), res))
+        });
+        eprintln!(
+            "  --only filter: {} -> {} cases",
+            before,
+            all_cases.len()
+        );
+    }
+
+    eprintln!(
+        "Total: {} test cases, {} thread(s), resolution-scaled iterations",
+        all_cases.len(),
+        num_threads,
+    );
+    eprintln!("Running benchmarks...");
+
+    let results = run_bench(all_cases, num_threads);
+
+    // Output TSV to file or stdout
+    if let Some(ref path) = output_tsv_path {
+        let mut file = std::fs::File::create(path).expect("Failed to create output TSV file");
+        write_tsv(&results, &mut file);
+        eprintln!("TSV results written to {}", path.display());
+    } else {
+        write_tsv(&results, &mut std::io::stdout());
+    }
+
+    // If comparing, load baseline and print comparison to stderr
+    if let Some(path) = compare_path {
+        let baseline = load_tsv(&path);
+        compare_results(&baseline, &results);
+    }
+
+    eprintln!("Done.");
+}

--- a/crates/resvg/examples/bench_e2e.rs
+++ b/crates/resvg/examples/bench_e2e.rs
@@ -133,7 +133,6 @@ fn gen_soft_blur(w: u32, h: u32) -> TestCase {
     }
 }
 
-
 fn gen_backdrop_blur(w: u32, h: u32) -> TestCase {
     let filter = r#"
     <filter id="f">
@@ -636,10 +635,7 @@ fn bench_one(case: &TestCase) -> f64 {
 
     if probe_ms >= SKIP_ITER_THRESHOLD_MS {
         // Degenerate case (e.g. huge-radius morphology): skip with probe as result.
-        eprintln!(
-            " [slow:{:.0}ms, skipping extra iters]",
-            probe_ms
-        );
+        eprintln!(" [slow:{:.0}ms, skipping extra iters]", probe_ms);
         return probe_ms;
     }
 
@@ -821,12 +817,7 @@ fn compare_results(baseline: &[BenchResult], optimized: &[BenchResult]) {
             }
 
             if speedup < 0.95 {
-                regressions.push((
-                    r.name.clone(),
-                    r.resolution.clone(),
-                    base_ms,
-                    r.median_ms,
-                ));
+                regressions.push((r.name.clone(), r.resolution.clone(), base_ms, r.median_ms));
             }
         }
     }
@@ -847,7 +838,10 @@ fn compare_results(baseline: &[BenchResult], optimized: &[BenchResult]) {
     }
 
     // Print existing SVG summary
-    eprintln!("\n=== Existing Test SVGs ({} files, 1x & 3x scale) ===\n", exist_1x_count.max(exist_3x_count));
+    eprintln!(
+        "\n=== Existing Test SVGs ({} files, 1x & 3x scale) ===\n",
+        exist_1x_count.max(exist_3x_count)
+    );
     if exist_1x_count > 0 {
         eprintln!("Total baseline (1x):  {:>10.3} ms", exist_1x_base);
         eprintln!("Total optimized (1x): {:>10.3} ms", exist_1x_opt);
@@ -989,11 +983,7 @@ fn main() {
             let res = format!("{}x{}", c.width, c.height);
             filter_set.contains(&(c.name.clone(), res))
         });
-        eprintln!(
-            "  --only filter: {} -> {} cases",
-            before,
-            all_cases.len()
-        );
+        eprintln!("  --only filter: {} -> {} cases", before, all_cases.len());
     }
 
     eprintln!(

--- a/crates/resvg/examples/bench_lighting_comprehensive.rs
+++ b/crates/resvg/examples/bench_lighting_comprehensive.rs
@@ -1,0 +1,586 @@
+// Copyright 2020 the Resvg Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Comprehensive benchmark for feDiffuseLighting and feSpecularLighting filters.
+//!
+//! Tests multiple image sizes, light source types, parameter combinations,
+//! and input patterns to detect performance regressions.
+//!
+//! Usage: cargo run --release --example bench_lighting_comprehensive [diffuse|specular|both]
+
+use std::time::Instant;
+
+/// Input pattern types for benchmark diversity.
+#[derive(Clone, Copy, Debug)]
+enum InputPattern {
+    /// All pixels have alpha=128 -- no surface variation, minimal normal computation.
+    Flat,
+    /// Linear alpha gradient from 0 to 255 -- typical use case.
+    Gradient,
+    /// Pseudo-random alpha values -- worst case for branch prediction / cache.
+    Noisy,
+}
+
+impl InputPattern {
+    fn name(&self) -> &'static str {
+        match self {
+            InputPattern::Flat => "flat",
+            InputPattern::Gradient => "gradient",
+            InputPattern::Noisy => "noisy",
+        }
+    }
+
+    fn fill_svg_element(&self, w: u32, h: u32) -> String {
+        match self {
+            InputPattern::Flat => {
+                // Solid gray rectangle -- uniform alpha
+                format!(
+                    r#"<rect width="{w}" height="{h}" fill="rgb(128,128,128)" fill-opacity="0.502"/>"#
+                )
+            }
+            InputPattern::Gradient => {
+                // Linear gradient from transparent to opaque
+                format!(
+                    r#"<defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0"/>
+      <stop offset="1" stop-color="white" stop-opacity="1"/>
+    </linearGradient>
+  </defs>
+  <rect width="{w}" height="{h}" fill="url(#grad)"/>"#
+                )
+            }
+            InputPattern::Noisy => {
+                // Checkerboard-like pattern with varying alpha using nested rects
+                // This creates surface variation through multiple overlapping elements.
+                let mut elements = format!(
+                    r#"<rect width="{w}" height="{h}" fill="gray" fill-opacity="0.3"/>"#
+                );
+                // Add some smaller rects at various positions to create alpha variation
+                let step = (w.max(h) / 8).max(1);
+                for i in 0..8 {
+                    let x = (i * step) % w;
+                    let y = (i * step) % h;
+                    let sw = (step * 3).min(w - x);
+                    let sh = (step * 2).min(h - y);
+                    let opacity = 0.1 + (i as f32 * 0.1);
+                    elements.push_str(&format!(
+                        r#"<rect x="{x}" y="{y}" width="{sw}" height="{sh}" fill="white" fill-opacity="{opacity:.1}"/>"#
+                    ));
+                }
+                elements
+            }
+        }
+    }
+}
+
+/// Configuration for a single benchmark case.
+struct BenchConfig {
+    filter_type: &'static str,
+    width: u32,
+    height: u32,
+    light_name: &'static str,
+    light_xml: String,
+    params_desc: String,
+    filter_attrs: String,
+    pattern: InputPattern,
+}
+
+fn generate_svg(config: &BenchConfig) -> String {
+    let w = config.width;
+    let h = config.height;
+    let fill_elements = config.pattern.fill_svg_element(w, h);
+
+    // Wrap fill elements in a group with the filter applied
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
+  <defs>
+    <filter id="f" x="0" y="0" width="100%" height="100%">
+      <{filter_type} {attrs} lighting-color="white">
+        {light}
+      </{filter_type}>
+    </filter>
+  </defs>
+  <g filter="url(#f)">
+    {fill}
+  </g>
+</svg>"##,
+        filter_type = config.filter_type,
+        attrs = config.filter_attrs,
+        light = config.light_xml,
+        fill = fill_elements,
+    )
+}
+
+fn pick_iterations(w: u32, h: u32) -> u32 {
+    let pixels = w as u64 * h as u64;
+    if pixels <= 16 {
+        10000
+    } else if pixels <= 256 {
+        5000
+    } else if pixels <= 1024 {
+        2000
+    } else if pixels <= 4096 {
+        1000
+    } else if pixels <= 16384 {
+        200
+    } else if pixels <= 65536 {
+        100
+    } else if pixels <= 262144 {
+        30
+    } else {
+        10
+    }
+}
+
+struct BenchResult {
+    filter_type: String,
+    size: String,
+    light_name: String,
+    params: String,
+    pattern: String,
+    time_us: f64,
+    mpix_per_s: f64,
+    iterations: u32,
+}
+
+fn run_bench(config: &BenchConfig) -> BenchResult {
+    let svg = generate_svg(config);
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    let mut pixmap = tiny_skia::Pixmap::new(config.width, config.height).unwrap();
+
+    // Warmup: 3 iterations
+    for _ in 0..3 {
+        resvg::render(
+            &tree,
+            tiny_skia::Transform::identity(),
+            &mut pixmap.as_mut(),
+        );
+    }
+
+    let iterations = pick_iterations(config.width, config.height);
+
+    // Benchmark with multiple rounds for stability
+    let mut best_time_us = f64::MAX;
+
+    for _round in 0..3 {
+        let start = Instant::now();
+        for _ in 0..iterations {
+            resvg::render(
+                &tree,
+                tiny_skia::Transform::identity(),
+                &mut pixmap.as_mut(),
+            );
+        }
+        let elapsed = start.elapsed();
+        let per_iter_us = elapsed.as_secs_f64() * 1_000_000.0 / iterations as f64;
+        if per_iter_us < best_time_us {
+            best_time_us = per_iter_us;
+        }
+    }
+
+    let pixels = config.width as f64 * config.height as f64;
+    let mpix_per_s = pixels / best_time_us; // us -> s would multiply by 1e6, but Mpix divides by 1e6
+
+    BenchResult {
+        filter_type: config.filter_type.to_string(),
+        size: format!("{}x{}", config.width, config.height),
+        light_name: config.light_name.to_string(),
+        params: config.params_desc.clone(),
+        pattern: config.pattern.name().to_string(),
+        time_us: best_time_us,
+        mpix_per_s,
+        iterations,
+    }
+}
+
+fn diffuse_configs() -> Vec<BenchConfig> {
+    let sizes: Vec<(u32, u32)> = vec![
+        (4, 4),
+        (16, 16),
+        (32, 32),
+        (64, 64),
+        (127, 127),  // Just below threshold (128*128 = 16384, 127*127 = 16129)
+        (128, 128),  // At threshold
+        (256, 256),
+        (512, 512),
+        (1024, 1024),
+    ];
+
+    let lights: Vec<(&str, String)> = vec![
+        (
+            "distant",
+            r#"<feDistantLight azimuth="45" elevation="55"/>"#.to_string(),
+        ),
+        (
+            "point",
+            r#"<fePointLight x="150" y="60" z="200"/>"#.to_string(),
+        ),
+        (
+            "spot",
+            r#"<feSpotLight x="150" y="60" z="200" pointsAtX="100" pointsAtY="100" pointsAtZ="0" specularExponent="8" limitingConeAngle="30"/>"#.to_string(),
+        ),
+    ];
+
+    let diffuse_params: Vec<(f32, f32, String)> = vec![
+        (0.5, 1.0, "dc=0.5,ss=1".to_string()),
+        (1.0, 1.0, "dc=1,ss=1".to_string()),
+        (1.0, 5.0, "dc=1,ss=5".to_string()),
+        (2.0, 5.0, "dc=2,ss=5".to_string()),
+        (1.0, 10.0, "dc=1,ss=10".to_string()),
+        (2.0, 10.0, "dc=2,ss=10".to_string()),
+    ];
+
+    let patterns = vec![InputPattern::Flat, InputPattern::Gradient, InputPattern::Noisy];
+
+    let mut configs = Vec::new();
+
+    for &(w, h) in &sizes {
+        for &(light_name, ref light_xml) in &lights {
+            for &(dc, ss, ref desc) in &diffuse_params {
+                for &pattern in &patterns {
+                    configs.push(BenchConfig {
+                        filter_type: "feDiffuseLighting",
+                        width: w,
+                        height: h,
+                        light_name,
+                        light_xml: light_xml.clone(),
+                        params_desc: desc.clone(),
+                        filter_attrs: format!(
+                            r#"surfaceScale="{ss}" diffuseConstant="{dc}""#
+                        ),
+                        pattern,
+                    });
+                }
+            }
+        }
+    }
+
+    configs
+}
+
+fn specular_configs() -> Vec<BenchConfig> {
+    let sizes: Vec<(u32, u32)> = vec![
+        (4, 4),
+        (16, 16),
+        (32, 32),
+        (64, 64),
+        (128, 128),
+        (256, 256),
+        (512, 512),
+        (1024, 1024),
+    ];
+
+    let lights: Vec<(&str, String)> = vec![
+        (
+            "distant",
+            r#"<feDistantLight azimuth="45" elevation="55"/>"#.to_string(),
+        ),
+        (
+            "point",
+            r#"<fePointLight x="150" y="60" z="200"/>"#.to_string(),
+        ),
+        (
+            "spot",
+            r#"<feSpotLight x="150" y="60" z="200" pointsAtX="100" pointsAtY="100" pointsAtZ="0" specularExponent="8" limitingConeAngle="30"/>"#.to_string(),
+        ),
+    ];
+
+    let specular_params: Vec<(f32, f32, f32, String)> = vec![
+        (1.0, 0.5, 1.0, "se=1,sc=0.5,ss=1".to_string()),
+        (1.0, 1.0, 1.0, "se=1,sc=1,ss=1".to_string()),
+        (5.0, 1.0, 1.0, "se=5,sc=1,ss=1".to_string()),
+        (5.0, 0.5, 5.0, "se=5,sc=0.5,ss=5".to_string()),
+        (20.0, 1.0, 1.0, "se=20,sc=1,ss=1".to_string()),
+        (20.0, 1.0, 5.0, "se=20,sc=1,ss=5".to_string()),
+        (128.0, 0.5, 1.0, "se=128,sc=0.5,ss=1".to_string()),
+        (128.0, 1.0, 5.0, "se=128,sc=1,ss=5".to_string()),
+    ];
+
+    let patterns = vec![InputPattern::Flat, InputPattern::Gradient, InputPattern::Noisy];
+
+    let mut configs = Vec::new();
+
+    for &(w, h) in &sizes {
+        for &(light_name, ref light_xml) in &lights {
+            for &(se, sc, ss, ref desc) in &specular_params {
+                for &pattern in &patterns {
+                    configs.push(BenchConfig {
+                        filter_type: "feSpecularLighting",
+                        width: w,
+                        height: h,
+                        light_name,
+                        light_xml: light_xml.clone(),
+                        params_desc: desc.clone(),
+                        filter_attrs: format!(
+                            r#"surfaceScale="{ss}" specularConstant="{sc}" specularExponent="{se}""#
+                        ),
+                        pattern,
+                    });
+                }
+            }
+        }
+    }
+
+    configs
+}
+
+fn print_results_table(filter_name: &str, results: &[BenchResult]) {
+    println!("\n{}", "=".repeat(120));
+    println!("  {} Performance Results", filter_name);
+    println!("{}", "=".repeat(120));
+    println!(
+        "{:<12} {:<10} {:<22} {:<10} {:>12} {:>12} {:>6}",
+        "Size", "Light", "Params", "Input", "Time (us)", "Mpix/s", "Iters"
+    );
+    println!("{}", "-".repeat(120));
+
+    let mut prev_size = String::new();
+    for r in results {
+        // Add separator between size groups
+        if r.size != prev_size && !prev_size.is_empty() {
+            println!("{}", "-".repeat(120));
+        }
+        prev_size = r.size.clone();
+
+        println!(
+            "{:<12} {:<10} {:<22} {:<10} {:>12.1} {:>12.2} {:>6}",
+            r.size, r.light_name, r.params, r.pattern, r.time_us, r.mpix_per_s, r.iterations
+        );
+    }
+    println!("{}", "=".repeat(120));
+}
+
+/// Print a summary table grouped by size and light type, averaging across params/patterns.
+fn print_summary_table(filter_name: &str, results: &[BenchResult]) {
+    println!("\n{}", "=".repeat(90));
+    println!("  {} Summary (averaged across params and input patterns)", filter_name);
+    println!("{}", "=".repeat(90));
+    println!(
+        "{:<12} {:<10} {:>15} {:>15} {:>12} {:>8}",
+        "Size", "Light", "Avg Time (us)", "Med Time (us)", "Avg Mpix/s", "Samples"
+    );
+    println!("{}", "-".repeat(90));
+
+    // Group by (size, light_name)
+    let mut groups: std::collections::BTreeMap<(String, String), Vec<f64>> =
+        std::collections::BTreeMap::new();
+
+    for r in results {
+        groups
+            .entry((r.size.clone(), r.light_name.clone()))
+            .or_default()
+            .push(r.time_us);
+    }
+
+    let mut prev_size = String::new();
+    for ((size, light), mut times) in groups {
+        if size != prev_size && !prev_size.is_empty() {
+            println!("{}", "-".repeat(90));
+        }
+        prev_size = size.clone();
+
+        times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let avg = times.iter().sum::<f64>() / times.len() as f64;
+        let median = if times.len() % 2 == 0 {
+            (times[times.len() / 2 - 1] + times[times.len() / 2]) / 2.0
+        } else {
+            times[times.len() / 2]
+        };
+
+        // Parse size for mpix calculation
+        let parts: Vec<&str> = size.split('x').collect();
+        let w: f64 = parts[0].parse().unwrap();
+        let h: f64 = parts[1].parse().unwrap();
+        let mpix = w * h / avg;
+
+        println!(
+            "{:<12} {:<10} {:>15.1} {:>15.1} {:>12.2} {:>8}",
+            size,
+            light,
+            avg,
+            median,
+            mpix,
+            times.len()
+        );
+    }
+    println!("{}", "=".repeat(90));
+}
+
+/// Run a focused threshold test for feDiffuseLighting around the 128x128 crossover.
+fn run_threshold_test() {
+    println!("\n{}", "=".repeat(100));
+    println!("  feDiffuseLighting Threshold Test (naive <128x128, optimized >=128x128)");
+    println!("{}", "=".repeat(100));
+
+    let threshold_sizes: Vec<(u32, u32, &str)> = vec![
+        (64, 64, "well-below"),
+        (100, 100, "below"),
+        (120, 120, "near-below"),
+        (127, 127, "just-below (naive)"),
+        (128, 128, "at-threshold (optimized)"),
+        (129, 129, "just-above (optimized)"),
+        (140, 140, "above"),
+        (160, 160, "well-above"),
+        (256, 256, "far-above"),
+    ];
+
+    let light_xml = r#"<feDistantLight azimuth="45" elevation="55"/>"#;
+
+    println!(
+        "{:<24} {:<18} {:>12} {:>12} {:>10}",
+        "Size", "Category", "Time (us)", "Mpix/s", "Path"
+    );
+    println!("{}", "-".repeat(100));
+
+    for &(w, h, category) in &threshold_sizes {
+        let config = BenchConfig {
+            filter_type: "feDiffuseLighting",
+            width: w,
+            height: h,
+            light_name: "distant",
+            light_xml: light_xml.to_string(),
+            params_desc: "dc=1,ss=5".to_string(),
+            filter_attrs: r#"surfaceScale="5" diffuseConstant="1""#.to_string(),
+            pattern: InputPattern::Gradient,
+        };
+
+        let result = run_bench(&config);
+        let path = if (w * h) < 128 * 128 { "NAIVE" } else { "OPTIMIZED" };
+
+        println!(
+            "{:<24} {:<18} {:>12.1} {:>12.2} {:>10}",
+            result.size, category, result.time_us, result.mpix_per_s, path
+        );
+    }
+    println!("{}", "=".repeat(100));
+}
+
+/// Check for potential regressions: flag any case where small images are anomalously slow.
+fn check_regressions(results: &[BenchResult], filter_name: &str) {
+    println!("\n{}", "=".repeat(80));
+    println!("  {} Regression Check (>5% slower than expected)", filter_name);
+    println!("{}", "=".repeat(80));
+
+    // Group results by (light, params, pattern) and check that larger images
+    // have proportionally better or equal Mpix/s throughput.
+    // A regression would be if Mpix/s drops significantly at a given size.
+
+    let mut groups: std::collections::HashMap<String, Vec<(u32, u32, f64, f64)>> =
+        std::collections::HashMap::new();
+
+    for r in results {
+        if r.filter_type != filter_name {
+            continue;
+        }
+        let key = format!("{}_{}_{}", r.light_name, r.params, r.pattern);
+        let parts: Vec<&str> = r.size.split('x').collect();
+        let w: u32 = parts[0].parse().unwrap();
+        let h: u32 = parts[1].parse().unwrap();
+        groups
+            .entry(key)
+            .or_default()
+            .push((w, h, r.time_us, r.mpix_per_s));
+    }
+
+    let mut regressions_found = false;
+
+    for (key, mut entries) in groups {
+        entries.sort_by_key(|&(w, h, _, _)| w * h);
+
+        // Check that throughput (Mpix/s) generally increases or stays stable
+        // as image size grows (larger images amortize overhead better).
+        // Flag cases where Mpix/s drops by >5% compared to the previous size.
+        for i in 1..entries.len() {
+            let (pw, ph, _pt, prev_mpix) = entries[i - 1];
+            let (cw, ch, _ct, cur_mpix) = entries[i];
+
+            // Only flag if current throughput is significantly lower than previous
+            // AND the current size is large enough to be meaningful (>= 32x32)
+            if cw * ch >= 32 * 32 && prev_mpix > 0.0 {
+                let ratio = cur_mpix / prev_mpix;
+                if ratio < 0.95 {
+                    println!(
+                        "  WARNING: {} -- {}x{} ({:.2} Mpix/s) is {:.1}% slower than {}x{} ({:.2} Mpix/s)",
+                        key,
+                        cw, ch, cur_mpix,
+                        (1.0 - ratio) * 100.0,
+                        pw, ph, prev_mpix,
+                    );
+                    regressions_found = true;
+                }
+            }
+        }
+    }
+
+    if !regressions_found {
+        println!("  No regressions detected (all throughput changes within 5% tolerance).");
+    }
+    println!("{}", "=".repeat(80));
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mode = args.get(1).map(|s| s.as_str()).unwrap_or("both");
+
+    let run_diffuse = mode == "diffuse" || mode == "both";
+    let run_specular = mode == "specular" || mode == "both";
+
+    println!("Comprehensive Lighting Filter Benchmark");
+    println!("Mode: {}", mode);
+    println!("Timestamp: {:?}", std::time::SystemTime::now());
+    println!();
+
+    if run_diffuse {
+        println!("Generating feDiffuseLighting benchmark configurations...");
+        let configs = diffuse_configs();
+        println!("Running {} feDiffuseLighting benchmarks...", configs.len());
+
+        let mut results = Vec::new();
+        let total = configs.len();
+        for (i, config) in configs.iter().enumerate() {
+            if (i + 1) % 10 == 0 || i + 1 == total {
+                eprint!(
+                    "\r  Progress: {}/{} ({:.0}%)",
+                    i + 1,
+                    total,
+                    (i + 1) as f64 / total as f64 * 100.0
+                );
+            }
+            results.push(run_bench(config));
+        }
+        eprintln!();
+
+        print_results_table("feDiffuseLighting", &results);
+        print_summary_table("feDiffuseLighting", &results);
+        run_threshold_test();
+        check_regressions(&results, "feDiffuseLighting");
+    }
+
+    if run_specular {
+        println!("\nGenerating feSpecularLighting benchmark configurations...");
+        let configs = specular_configs();
+        println!("Running {} feSpecularLighting benchmarks...", configs.len());
+
+        let mut results = Vec::new();
+        let total = configs.len();
+        for (i, config) in configs.iter().enumerate() {
+            if (i + 1) % 10 == 0 || i + 1 == total {
+                eprint!(
+                    "\r  Progress: {}/{} ({:.0}%)",
+                    i + 1,
+                    total,
+                    (i + 1) as f64 / total as f64 * 100.0
+                );
+            }
+            results.push(run_bench(config));
+        }
+        eprintln!();
+
+        print_results_table("feSpecularLighting", &results);
+        print_summary_table("feSpecularLighting", &results);
+        check_regressions(&results, "feSpecularLighting");
+    }
+
+    println!("\nBenchmark complete.");
+}

--- a/crates/resvg/examples/bench_lighting_comprehensive.rs
+++ b/crates/resvg/examples/bench_lighting_comprehensive.rs
@@ -53,9 +53,8 @@ impl InputPattern {
             InputPattern::Noisy => {
                 // Checkerboard-like pattern with varying alpha using nested rects
                 // This creates surface variation through multiple overlapping elements.
-                let mut elements = format!(
-                    r#"<rect width="{w}" height="{h}" fill="gray" fill-opacity="0.3"/>"#
-                );
+                let mut elements =
+                    format!(r#"<rect width="{w}" height="{h}" fill="gray" fill-opacity="0.3"/>"#);
                 // Add some smaller rects at various positions to create alpha variation
                 let step = (w.max(h) / 8).max(1);
                 for i in 0..8 {
@@ -200,8 +199,8 @@ fn diffuse_configs() -> Vec<BenchConfig> {
         (16, 16),
         (32, 32),
         (64, 64),
-        (127, 127),  // Just below threshold (128*128 = 16384, 127*127 = 16129)
-        (128, 128),  // At threshold
+        (127, 127), // Just below threshold (128*128 = 16384, 127*127 = 16129)
+        (128, 128), // At threshold
         (256, 256),
         (512, 512),
         (1024, 1024),
@@ -231,7 +230,11 @@ fn diffuse_configs() -> Vec<BenchConfig> {
         (2.0, 10.0, "dc=2,ss=10".to_string()),
     ];
 
-    let patterns = vec![InputPattern::Flat, InputPattern::Gradient, InputPattern::Noisy];
+    let patterns = vec![
+        InputPattern::Flat,
+        InputPattern::Gradient,
+        InputPattern::Noisy,
+    ];
 
     let mut configs = Vec::new();
 
@@ -246,9 +249,7 @@ fn diffuse_configs() -> Vec<BenchConfig> {
                         light_name,
                         light_xml: light_xml.clone(),
                         params_desc: desc.clone(),
-                        filter_attrs: format!(
-                            r#"surfaceScale="{ss}" diffuseConstant="{dc}""#
-                        ),
+                        filter_attrs: format!(r#"surfaceScale="{ss}" diffuseConstant="{dc}""#),
                         pattern,
                     });
                 }
@@ -297,7 +298,11 @@ fn specular_configs() -> Vec<BenchConfig> {
         (128.0, 1.0, 5.0, "se=128,sc=1,ss=5".to_string()),
     ];
 
-    let patterns = vec![InputPattern::Flat, InputPattern::Gradient, InputPattern::Noisy];
+    let patterns = vec![
+        InputPattern::Flat,
+        InputPattern::Gradient,
+        InputPattern::Noisy,
+    ];
 
     let mut configs = Vec::new();
 
@@ -354,7 +359,10 @@ fn print_results_table(filter_name: &str, results: &[BenchResult]) {
 /// Print a summary table grouped by size and light type, averaging across params/patterns.
 fn print_summary_table(filter_name: &str, results: &[BenchResult]) {
     println!("\n{}", "=".repeat(90));
-    println!("  {} Summary (averaged across params and input patterns)", filter_name);
+    println!(
+        "  {} Summary (averaged across params and input patterns)",
+        filter_name
+    );
     println!("{}", "=".repeat(90));
     println!(
         "{:<12} {:<10} {:>15} {:>15} {:>12} {:>8}",
@@ -446,7 +454,11 @@ fn run_threshold_test() {
         };
 
         let result = run_bench(&config);
-        let path = if (w * h) < 128 * 128 { "NAIVE" } else { "OPTIMIZED" };
+        let path = if (w * h) < 128 * 128 {
+            "NAIVE"
+        } else {
+            "OPTIMIZED"
+        };
 
         println!(
             "{:<24} {:<18} {:>12.1} {:>12.2} {:>10}",
@@ -459,7 +471,10 @@ fn run_threshold_test() {
 /// Check for potential regressions: flag any case where small images are anomalously slow.
 fn check_regressions(results: &[BenchResult], filter_name: &str) {
     println!("\n{}", "=".repeat(80));
-    println!("  {} Regression Check (>5% slower than expected)", filter_name);
+    println!(
+        "  {} Regression Check (>5% slower than expected)",
+        filter_name
+    );
     println!("{}", "=".repeat(80));
 
     // Group results by (light, params, pattern) and check that larger images
@@ -503,9 +518,13 @@ fn check_regressions(results: &[BenchResult], filter_name: &str) {
                     println!(
                         "  WARNING: {} -- {}x{} ({:.2} Mpix/s) is {:.1}% slower than {}x{} ({:.2} Mpix/s)",
                         key,
-                        cw, ch, cur_mpix,
+                        cw,
+                        ch,
+                        cur_mpix,
                         (1.0 - ratio) * 100.0,
-                        pw, ph, prev_mpix,
+                        pw,
+                        ph,
+                        prev_mpix,
                     );
                     regressions_found = true;
                 }

--- a/crates/resvg/examples/bench_lighting_quick.rs
+++ b/crates/resvg/examples/bench_lighting_quick.rs
@@ -1,0 +1,152 @@
+// Copyright 2020 the Resvg Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Quick comparison benchmark for feDiffuseLighting and feSpecularLighting.
+//! Runs a representative subset of configurations for fast regression detection.
+//!
+//! Usage: cargo run --release --example bench_lighting_quick
+
+use std::time::Instant;
+
+struct BenchCase {
+    name: &'static str,
+    svg: String,
+    width: u32,
+    height: u32,
+}
+
+fn make_diffuse_svg(w: u32, h: u32, light: &str, dc: f32, ss: f32) -> String {
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0"/>
+      <stop offset="1" stop-color="white" stop-opacity="1"/>
+    </linearGradient>
+    <filter id="f" x="0" y="0" width="100%" height="100%">
+      <feDiffuseLighting surfaceScale="{ss}" diffuseConstant="{dc}" lighting-color="white">
+        {light}
+      </feDiffuseLighting>
+    </filter>
+  </defs>
+  <g filter="url(#f)">
+    <rect width="{w}" height="{h}" fill="url(#g)"/>
+  </g>
+</svg>"##,
+    )
+}
+
+fn make_specular_svg(w: u32, h: u32, light: &str, se: f32, sc: f32, ss: f32) -> String {
+    format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="white" stop-opacity="0"/>
+      <stop offset="1" stop-color="white" stop-opacity="1"/>
+    </linearGradient>
+    <filter id="f" x="0" y="0" width="100%" height="100%">
+      <feSpecularLighting surfaceScale="{ss}" specularConstant="{sc}" specularExponent="{se}" lighting-color="white">
+        {light}
+      </feSpecularLighting>
+    </filter>
+  </defs>
+  <g filter="url(#f)">
+    <rect width="{w}" height="{h}" fill="url(#g)"/>
+  </g>
+</svg>"##,
+    )
+}
+
+fn pick_iters(w: u32, h: u32) -> u32 {
+    let p = w as u64 * h as u64;
+    if p <= 256 { 5000 }
+    else if p <= 4096 { 2000 }
+    else if p <= 16384 { 500 }
+    else if p <= 65536 { 200 }
+    else if p <= 262144 { 50 }
+    else { 10 }
+}
+
+fn bench(case: &BenchCase) -> f64 {
+    let tree = usvg::Tree::from_str(&case.svg, &usvg::Options::default()).unwrap();
+    let mut pixmap = tiny_skia::Pixmap::new(case.width, case.height).unwrap();
+
+    // warmup
+    for _ in 0..3 {
+        resvg::render(&tree, tiny_skia::Transform::identity(), &mut pixmap.as_mut());
+    }
+
+    let iters = pick_iters(case.width, case.height);
+    let mut best = f64::MAX;
+
+    for _ in 0..3 {
+        let start = Instant::now();
+        for _ in 0..iters {
+            resvg::render(&tree, tiny_skia::Transform::identity(), &mut pixmap.as_mut());
+        }
+        let us = start.elapsed().as_secs_f64() * 1e6 / iters as f64;
+        if us < best { best = us; }
+    }
+    best
+}
+
+fn main() {
+    let distant = r#"<feDistantLight azimuth="45" elevation="55"/>"#;
+    let point = r#"<fePointLight x="150" y="60" z="200"/>"#;
+    let spot = r#"<feSpotLight x="150" y="60" z="200" pointsAtX="100" pointsAtY="100" pointsAtZ="0" specularExponent="8" limitingConeAngle="30"/>"#;
+
+    let sizes: &[(u32, u32)] = &[
+        (4, 4), (16, 16), (32, 32), (64, 64),
+        (127, 127), (128, 128), (129, 129),
+        (256, 256), (512, 512), (1024, 1024),
+    ];
+
+    // ==================== feDiffuseLighting ====================
+    println!("feDiffuseLighting Quick Benchmark");
+    println!("{:<14} {:<10} {:<16} {:>12} {:>12}", "Size", "Light", "Params", "Time(us)", "Mpix/s");
+    println!("{}", "-".repeat(70));
+
+    let lights: &[(&str, &str)] = &[("distant", distant), ("point", point), ("spot", spot)];
+    let diff_params: &[(f32, f32, &str)] = &[
+        (1.0, 1.0, "dc=1,ss=1"),
+        (1.0, 5.0, "dc=1,ss=5"),
+        (2.0, 10.0, "dc=2,ss=10"),
+    ];
+
+    for &(w, h) in sizes {
+        for &(lname, lxml) in lights {
+            for &(dc, ss, pdesc) in diff_params {
+                let svg = make_diffuse_svg(w, h, lxml, dc, ss);
+                let c = BenchCase { name: "diffuse", svg, width: w, height: h };
+                let us = bench(&c);
+                let mpix = (w as f64 * h as f64) / us;
+                println!("{:<14} {:<10} {:<16} {:>12.1} {:>12.2}", format!("{}x{}", w, h), lname, pdesc, us, mpix);
+            }
+        }
+        println!("{}", "-".repeat(70));
+    }
+
+    // ==================== feSpecularLighting ====================
+    println!("\nfeSpecularLighting Quick Benchmark");
+    println!("{:<14} {:<10} {:<16} {:>12} {:>12}", "Size", "Light", "Params", "Time(us)", "Mpix/s");
+    println!("{}", "-".repeat(70));
+
+    let spec_params: &[(f32, f32, f32, &str)] = &[
+        (1.0, 1.0, 1.0, "se=1,sc=1,ss=1"),
+        (20.0, 1.0, 5.0, "se=20,sc=1,ss=5"),
+        (128.0, 0.5, 1.0, "se=128,sc=.5,ss=1"),
+    ];
+
+    for &(w, h) in sizes {
+        for &(lname, lxml) in lights {
+            for &(se, sc, ss, pdesc) in spec_params {
+                let svg = make_specular_svg(w, h, lxml, se, sc, ss);
+                let c = BenchCase { name: "specular", svg, width: w, height: h };
+                let us = bench(&c);
+                let mpix = (w as f64 * h as f64) / us;
+                println!("{:<14} {:<10} {:<16} {:>12.1} {:>12.2}", format!("{}x{}", w, h), lname, pdesc, us, mpix);
+            }
+        }
+        println!("{}", "-".repeat(70));
+    }
+}

--- a/crates/resvg/examples/bench_lighting_quick.rs
+++ b/crates/resvg/examples/bench_lighting_quick.rs
@@ -59,12 +59,19 @@ fn make_specular_svg(w: u32, h: u32, light: &str, se: f32, sc: f32, ss: f32) -> 
 
 fn pick_iters(w: u32, h: u32) -> u32 {
     let p = w as u64 * h as u64;
-    if p <= 256 { 5000 }
-    else if p <= 4096 { 2000 }
-    else if p <= 16384 { 500 }
-    else if p <= 65536 { 200 }
-    else if p <= 262144 { 50 }
-    else { 10 }
+    if p <= 256 {
+        5000
+    } else if p <= 4096 {
+        2000
+    } else if p <= 16384 {
+        500
+    } else if p <= 65536 {
+        200
+    } else if p <= 262144 {
+        50
+    } else {
+        10
+    }
 }
 
 fn bench(case: &BenchCase) -> f64 {
@@ -73,7 +80,11 @@ fn bench(case: &BenchCase) -> f64 {
 
     // warmup
     for _ in 0..3 {
-        resvg::render(&tree, tiny_skia::Transform::identity(), &mut pixmap.as_mut());
+        resvg::render(
+            &tree,
+            tiny_skia::Transform::identity(),
+            &mut pixmap.as_mut(),
+        );
     }
 
     let iters = pick_iters(case.width, case.height);
@@ -82,10 +93,16 @@ fn bench(case: &BenchCase) -> f64 {
     for _ in 0..3 {
         let start = Instant::now();
         for _ in 0..iters {
-            resvg::render(&tree, tiny_skia::Transform::identity(), &mut pixmap.as_mut());
+            resvg::render(
+                &tree,
+                tiny_skia::Transform::identity(),
+                &mut pixmap.as_mut(),
+            );
         }
         let us = start.elapsed().as_secs_f64() * 1e6 / iters as f64;
-        if us < best { best = us; }
+        if us < best {
+            best = us;
+        }
     }
     best
 }
@@ -96,14 +113,24 @@ fn main() {
     let spot = r#"<feSpotLight x="150" y="60" z="200" pointsAtX="100" pointsAtY="100" pointsAtZ="0" specularExponent="8" limitingConeAngle="30"/>"#;
 
     let sizes: &[(u32, u32)] = &[
-        (4, 4), (16, 16), (32, 32), (64, 64),
-        (127, 127), (128, 128), (129, 129),
-        (256, 256), (512, 512), (1024, 1024),
+        (4, 4),
+        (16, 16),
+        (32, 32),
+        (64, 64),
+        (127, 127),
+        (128, 128),
+        (129, 129),
+        (256, 256),
+        (512, 512),
+        (1024, 1024),
     ];
 
     // ==================== feDiffuseLighting ====================
     println!("feDiffuseLighting Quick Benchmark");
-    println!("{:<14} {:<10} {:<16} {:>12} {:>12}", "Size", "Light", "Params", "Time(us)", "Mpix/s");
+    println!(
+        "{:<14} {:<10} {:<16} {:>12} {:>12}",
+        "Size", "Light", "Params", "Time(us)", "Mpix/s"
+    );
     println!("{}", "-".repeat(70));
 
     let lights: &[(&str, &str)] = &[("distant", distant), ("point", point), ("spot", spot)];
@@ -117,10 +144,22 @@ fn main() {
         for &(lname, lxml) in lights {
             for &(dc, ss, pdesc) in diff_params {
                 let svg = make_diffuse_svg(w, h, lxml, dc, ss);
-                let c = BenchCase { name: "diffuse", svg, width: w, height: h };
+                let c = BenchCase {
+                    name: "diffuse",
+                    svg,
+                    width: w,
+                    height: h,
+                };
                 let us = bench(&c);
                 let mpix = (w as f64 * h as f64) / us;
-                println!("{:<14} {:<10} {:<16} {:>12.1} {:>12.2}", format!("{}x{}", w, h), lname, pdesc, us, mpix);
+                println!(
+                    "{:<14} {:<10} {:<16} {:>12.1} {:>12.2}",
+                    format!("{}x{}", w, h),
+                    lname,
+                    pdesc,
+                    us,
+                    mpix
+                );
             }
         }
         println!("{}", "-".repeat(70));
@@ -128,7 +167,10 @@ fn main() {
 
     // ==================== feSpecularLighting ====================
     println!("\nfeSpecularLighting Quick Benchmark");
-    println!("{:<14} {:<10} {:<16} {:>12} {:>12}", "Size", "Light", "Params", "Time(us)", "Mpix/s");
+    println!(
+        "{:<14} {:<10} {:<16} {:>12} {:>12}",
+        "Size", "Light", "Params", "Time(us)", "Mpix/s"
+    );
     println!("{}", "-".repeat(70));
 
     let spec_params: &[(f32, f32, f32, &str)] = &[
@@ -141,10 +183,22 @@ fn main() {
         for &(lname, lxml) in lights {
             for &(se, sc, ss, pdesc) in spec_params {
                 let svg = make_specular_svg(w, h, lxml, se, sc, ss);
-                let c = BenchCase { name: "specular", svg, width: w, height: h };
+                let c = BenchCase {
+                    name: "specular",
+                    svg,
+                    width: w,
+                    height: h,
+                };
                 let us = bench(&c);
                 let mpix = (w as f64 * h as f64) / us;
-                println!("{:<14} {:<10} {:<16} {:>12.1} {:>12.2}", format!("{}x{}", w, h), lname, pdesc, us, mpix);
+                println!(
+                    "{:<14} {:<10} {:<16} {:>12.1} {:>12.2}",
+                    format!("{}x{}", w, h),
+                    lname,
+                    pdesc,
+                    us,
+                    mpix
+                );
             }
         }
         println!("{}", "-".repeat(70));

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -352,7 +352,15 @@ fn specular_lighting_optimized(
 
     // Helper to compute the light vector for point/spot lights (identical logic).
     #[inline(always)]
-    fn point_light_vector(src: ImageRef, nx: u32, ny: u32, lx: f32, ly: f32, lz: f32, surface_scale: f32) -> Vector3 {
+    fn point_light_vector(
+        src: ImageRef,
+        nx: u32,
+        ny: u32,
+        lx: f32,
+        ly: f32,
+        lz: f32,
+        surface_scale: f32,
+    ) -> Vector3 {
         let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
         let origin = Vector3::new(lx, ly, lz);
         let v = origin - Vector3::new(nx as f32, ny as f32, nz);
@@ -377,9 +385,17 @@ fn specular_lighting_optimized(
             macro_rules! calc_distant {
                 ($nx:expr, $ny:expr, $normal:expr) => {
                     write_pixel(
-                        &mut dest, $nx, $ny,
-                        light_vector, ls_ref, lighting_color, $normal,
-                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                        &mut dest,
+                        $nx,
+                        $ny,
+                        light_vector,
+                        ls_ref,
+                        lighting_color,
+                        $normal,
+                        specular_exponent,
+                        specular_constant,
+                        exp_is_one,
+                        scale_factor,
                     )
                 };
             }
@@ -411,9 +427,17 @@ fn specular_lighting_optimized(
                 ($nx:expr, $ny:expr, $normal:expr) => {{
                     let lv = point_light_vector(src, $nx, $ny, lx, ly, lz, surface_scale);
                     write_pixel(
-                        &mut dest, $nx, $ny,
-                        lv, ls_ref, lighting_color, $normal,
-                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                        &mut dest,
+                        $nx,
+                        $ny,
+                        lv,
+                        ls_ref,
+                        lighting_color,
+                        $normal,
+                        specular_exponent,
+                        specular_constant,
+                        exp_is_one,
+                        scale_factor,
                     )
                 }};
             }
@@ -445,9 +469,17 @@ fn specular_lighting_optimized(
                 ($nx:expr, $ny:expr, $normal:expr) => {{
                     let lv = point_light_vector(src, $nx, $ny, lx, ly, lz, surface_scale);
                     write_pixel(
-                        &mut dest, $nx, $ny,
-                        lv, ls_ref, lighting_color, $normal,
-                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                        &mut dest,
+                        $nx,
+                        $ny,
+                        lv,
+                        ls_ref,
+                        lighting_color,
+                        $normal,
+                        specular_exponent,
+                        specular_constant,
+                        exp_is_one,
+                        scale_factor,
                     )
                 }};
             }

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -188,7 +188,7 @@ pub fn specular_lighting(
 }
 
 /// The original (naive) specular lighting implementation, preserved verbatim.
-#[allow(dead_code)]
+#[cfg(test)]
 fn specular_lighting_naive(
     fe: &SpecularLighting,
     light_source: LightSource,
@@ -242,9 +242,18 @@ fn specular_lighting_naive(
 /// Optimized specular lighting implementation.
 ///
 /// Key optimizations over the naive version:
-/// 1. Monomorphized (no `dyn Fn` trait object) for better inlining by LLVM
-/// 2. Specular exponent == 1.0 check is done once upfront, not per-pixel
-/// 3. Pre-computed surface_scale / 255.0 factor
+/// 1. **Devirtualization / inlining**: the specular factor computation is a
+///    monomorphized `#[inline] fn` instead of a `dyn Fn` trait-object closure
+///    passed through `apply()`. This lets LLVM inline and optimise the hot path
+///    without indirect-call overhead.
+/// 2. Specular-exponent == 1.0 boolean (`exp_is_one`) is hoisted out of the
+///    per-pixel loop so the branch predictor sees a loop-invariant condition.
+/// 3. `surface_scale / 255.0` is pre-computed once (`scale_factor`) instead of
+///    being recalculated for every pixel.
+///
+/// Note: this is *not* a SIMD or data-layout optimisation. The pixel data is
+/// still in AoS `RGBA8` order and the per-pixel branching prevents
+/// auto-vectorisation.
 fn specular_lighting_optimized(
     fe: &SpecularLighting,
     light_source: LightSource,
@@ -322,6 +331,9 @@ fn specular_lighting_optimized(
     let mut calc = |nx, ny, normal: Normal| {
         match light_source {
             LightSource::DistantLight(_) => {}
+            // Note: PointLight and SpotLight arms are identical but cannot be
+            // merged with an or-pattern because `PointLight` and `SpotLight`
+            // are distinct types — Rust requires a single binding type per arm.
             LightSource::PointLight(ref light) => {
                 let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
                 let origin = Vector3::new(light.x, light.y, light.z);

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -256,7 +256,6 @@ fn specular_lighting_naive(
 /// Note: this is *not* a SIMD or data-layout optimisation. The pixel data is
 /// still in AoS `RGBA8` order and the per-pixel branching prevents
 /// auto-vectorisation.
-#[inline(never)]
 fn specular_lighting_optimized(
     fe: &SpecularLighting,
     light_source: LightSource,
@@ -276,21 +275,7 @@ fn specular_lighting_optimized(
     let exp_is_one = specular_exponent.approx_eq_ulps(&1.0, 4);
     let scale_factor = surface_scale / 255.0;
 
-    // `feDistantLight` has a fixed vector, so calculate it beforehand.
-    let mut light_vector = match light_source {
-        LightSource::DistantLight(light) => {
-            let azimuth = light.azimuth.to_radians();
-            let elevation = light.elevation.to_radians();
-            Vector3::new(
-                azimuth.cos() * elevation.cos(),
-                azimuth.sin() * elevation.cos(),
-                elevation.sin(),
-            )
-        }
-        _ => Vector3::new(1.0, 1.0, 1.0),
-    };
-
-    #[inline]
+    #[inline(always)]
     fn specular_factor(
         normal: Normal,
         light_vector: Vector3,
@@ -331,27 +316,21 @@ fn specular_lighting_optimized(
         specular_constant * k
     }
 
-    let mut calc = |nx, ny, normal: Normal| {
-        match light_source {
-            LightSource::DistantLight(_) => {}
-            // Note: PointLight and SpotLight arms are identical but cannot be
-            // merged with an or-pattern because `PointLight` and `SpotLight`
-            // are distinct types — Rust requires a single binding type per arm.
-            LightSource::PointLight(ref light) => {
-                let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
-                let origin = Vector3::new(light.x, light.y, light.z);
-                let v = origin - Vector3::new(nx as f32, ny as f32, nz);
-                light_vector = v.normalized().unwrap_or(v);
-            }
-            LightSource::SpotLight(ref light) => {
-                let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
-                let origin = Vector3::new(light.x, light.y, light.z);
-                let v = origin - Vector3::new(nx as f32, ny as f32, nz);
-                light_vector = v.normalized().unwrap_or(v);
-            }
-        }
-
-        let light_color = light_color(&light_source, lighting_color, light_vector);
+    #[inline(always)]
+    fn write_pixel(
+        dest: &mut ImageRefMut,
+        nx: u32,
+        ny: u32,
+        light_vector: Vector3,
+        light_source: &LightSource,
+        lighting_color: Color,
+        normal: Normal,
+        specular_exponent: f32,
+        specular_constant: f32,
+        exp_is_one: bool,
+        scale_factor: f32,
+    ) {
+        let light_color = light_color(light_source, lighting_color, light_vector);
         let factor = specular_factor(
             normal,
             light_vector,
@@ -369,26 +348,128 @@ fn specular_lighting_optimized(
         let a = calc_specular_alpha(r, g, b);
 
         *dest.pixel_at_mut(nx, ny) = RGBA8 { b, g, r, a };
-    };
-
-    calc(0, 0, top_left_normal(src));
-    calc(width - 1, 0, top_right_normal(src));
-    calc(0, height - 1, bottom_left_normal(src));
-    calc(width - 1, height - 1, bottom_right_normal(src));
-
-    for x in 1..width - 1 {
-        calc(x, 0, top_row_normal(src, x));
-        calc(x, height - 1, bottom_row_normal(src, x));
     }
 
-    for y in 1..height - 1 {
-        calc(0, y, left_column_normal(src, y));
-        calc(width - 1, y, right_column_normal(src, y));
+    // Helper to compute the light vector for point/spot lights (identical logic).
+    #[inline(always)]
+    fn point_light_vector(src: ImageRef, nx: u32, ny: u32, lx: f32, ly: f32, lz: f32, surface_scale: f32) -> Vector3 {
+        let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
+        let origin = Vector3::new(lx, ly, lz);
+        let v = origin - Vector3::new(nx as f32, ny as f32, nz);
+        v.normalized().unwrap_or(v)
     }
 
-    for y in 1..height - 1 {
-        for x in 1..width - 1 {
-            calc(x, y, interior_normal(src, x, y));
+    // Hoist the light-type match OUTSIDE the pixel loop so that each branch
+    // gets its own monomorphized inner loop.  This eliminates the per-pixel
+    // branch and lets LLVM reason about (and vectorise) each loop body
+    // independently.
+    match light_source {
+        LightSource::DistantLight(ref dl) => {
+            let azimuth = dl.azimuth.to_radians();
+            let elevation = dl.elevation.to_radians();
+            let light_vector = Vector3::new(
+                azimuth.cos() * elevation.cos(),
+                azimuth.sin() * elevation.cos(),
+                elevation.sin(),
+            );
+            let ls_ref = &light_source;
+
+            macro_rules! calc_distant {
+                ($nx:expr, $ny:expr, $normal:expr) => {
+                    write_pixel(
+                        &mut dest, $nx, $ny,
+                        light_vector, ls_ref, lighting_color, $normal,
+                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                    )
+                };
+            }
+
+            calc_distant!(0, 0, top_left_normal(src));
+            calc_distant!(width - 1, 0, top_right_normal(src));
+            calc_distant!(0, height - 1, bottom_left_normal(src));
+            calc_distant!(width - 1, height - 1, bottom_right_normal(src));
+
+            for x in 1..width - 1 {
+                calc_distant!(x, 0, top_row_normal(src, x));
+                calc_distant!(x, height - 1, bottom_row_normal(src, x));
+            }
+            for y in 1..height - 1 {
+                calc_distant!(0, y, left_column_normal(src, y));
+                calc_distant!(width - 1, y, right_column_normal(src, y));
+            }
+            for y in 1..height - 1 {
+                for x in 1..width - 1 {
+                    calc_distant!(x, y, interior_normal(src, x, y));
+                }
+            }
+        }
+        LightSource::PointLight(ref pl) => {
+            let (lx, ly, lz) = (pl.x, pl.y, pl.z);
+            let ls_ref = &light_source;
+
+            macro_rules! calc_point {
+                ($nx:expr, $ny:expr, $normal:expr) => {{
+                    let lv = point_light_vector(src, $nx, $ny, lx, ly, lz, surface_scale);
+                    write_pixel(
+                        &mut dest, $nx, $ny,
+                        lv, ls_ref, lighting_color, $normal,
+                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                    )
+                }};
+            }
+
+            calc_point!(0, 0, top_left_normal(src));
+            calc_point!(width - 1, 0, top_right_normal(src));
+            calc_point!(0, height - 1, bottom_left_normal(src));
+            calc_point!(width - 1, height - 1, bottom_right_normal(src));
+
+            for x in 1..width - 1 {
+                calc_point!(x, 0, top_row_normal(src, x));
+                calc_point!(x, height - 1, bottom_row_normal(src, x));
+            }
+            for y in 1..height - 1 {
+                calc_point!(0, y, left_column_normal(src, y));
+                calc_point!(width - 1, y, right_column_normal(src, y));
+            }
+            for y in 1..height - 1 {
+                for x in 1..width - 1 {
+                    calc_point!(x, y, interior_normal(src, x, y));
+                }
+            }
+        }
+        LightSource::SpotLight(ref sl) => {
+            let (lx, ly, lz) = (sl.x, sl.y, sl.z);
+            let ls_ref = &light_source;
+
+            macro_rules! calc_spot {
+                ($nx:expr, $ny:expr, $normal:expr) => {{
+                    let lv = point_light_vector(src, $nx, $ny, lx, ly, lz, surface_scale);
+                    write_pixel(
+                        &mut dest, $nx, $ny,
+                        lv, ls_ref, lighting_color, $normal,
+                        specular_exponent, specular_constant, exp_is_one, scale_factor,
+                    )
+                }};
+            }
+
+            calc_spot!(0, 0, top_left_normal(src));
+            calc_spot!(width - 1, 0, top_right_normal(src));
+            calc_spot!(0, height - 1, bottom_left_normal(src));
+            calc_spot!(width - 1, height - 1, bottom_right_normal(src));
+
+            for x in 1..width - 1 {
+                calc_spot!(x, 0, top_row_normal(src, x));
+                calc_spot!(x, height - 1, bottom_row_normal(src, x));
+            }
+            for y in 1..height - 1 {
+                calc_spot!(0, y, left_column_normal(src, y));
+                calc_spot!(width - 1, y, right_column_normal(src, y));
+            }
+            for y in 1..height - 1 {
+                for x in 1..width - 1 {
+                    calc_spot!(x, y, interior_normal(src, x, y));
+                }
+            }
         }
     }
 }

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -187,7 +187,9 @@ pub fn specular_lighting(
     specular_lighting_optimized(fe, light_source, src, dest);
 }
 
-/// The original (naive) specular lighting implementation, preserved verbatim.
+/// Original specular lighting implementation using the generic `apply()` path.
+/// Retained under `#[cfg(test)]` as the correctness reference for bit-exact
+/// comparison against the optimized version.
 #[cfg(test)]
 fn specular_lighting_naive(
     fe: &SpecularLighting,

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -254,6 +254,7 @@ fn specular_lighting_naive(
 /// Note: this is *not* a SIMD or data-layout optimisation. The pixel data is
 /// still in AoS `RGBA8` order and the per-pixel branching prevents
 /// auto-vectorisation.
+#[inline(never)]
 fn specular_lighting_optimized(
     fe: &SpecularLighting,
     light_source: LightSource,

--- a/crates/resvg/src/filter/lighting.rs
+++ b/crates/resvg/src/filter/lighting.rs
@@ -184,6 +184,17 @@ pub fn specular_lighting(
 ) {
     assert!(src.width == dest.width && src.height == dest.height);
 
+    specular_lighting_optimized(fe, light_source, src, dest);
+}
+
+/// The original (naive) specular lighting implementation, preserved verbatim.
+#[allow(dead_code)]
+fn specular_lighting_naive(
+    fe: &SpecularLighting,
+    light_source: LightSource,
+    src: ImageRef,
+    dest: ImageRefMut,
+) {
     let light_factor = |normal: Normal, light_vector: Vector3| {
         let h = light_vector + Vector3::new(0.0, 0.0, 1.0);
         let h_length = h.length();
@@ -226,6 +237,145 @@ pub fn specular_lighting(
         src,
         dest,
     );
+}
+
+/// Optimized specular lighting implementation.
+///
+/// Key optimizations over the naive version:
+/// 1. Monomorphized (no `dyn Fn` trait object) for better inlining by LLVM
+/// 2. Specular exponent == 1.0 check is done once upfront, not per-pixel
+/// 3. Pre-computed surface_scale / 255.0 factor
+fn specular_lighting_optimized(
+    fe: &SpecularLighting,
+    light_source: LightSource,
+    src: ImageRef,
+    mut dest: ImageRefMut,
+) {
+    if src.width < 3 || src.height < 3 {
+        return;
+    }
+
+    let width = src.width;
+    let height = src.height;
+    let surface_scale = fe.surface_scale();
+    let specular_exponent = fe.specular_exponent();
+    let specular_constant = fe.specular_constant();
+    let lighting_color = fe.lighting_color();
+    let exp_is_one = specular_exponent.approx_eq_ulps(&1.0, 4);
+    let scale_factor = surface_scale / 255.0;
+
+    // `feDistantLight` has a fixed vector, so calculate it beforehand.
+    let mut light_vector = match light_source {
+        LightSource::DistantLight(light) => {
+            let azimuth = light.azimuth.to_radians();
+            let elevation = light.elevation.to_radians();
+            Vector3::new(
+                azimuth.cos() * elevation.cos(),
+                azimuth.sin() * elevation.cos(),
+                elevation.sin(),
+            )
+        }
+        _ => Vector3::new(1.0, 1.0, 1.0),
+    };
+
+    #[inline]
+    fn specular_factor(
+        normal: Normal,
+        light_vector: Vector3,
+        specular_exponent: f32,
+        specular_constant: f32,
+        exp_is_one: bool,
+        scale_factor: f32,
+    ) -> f32 {
+        let h = light_vector + Vector3::new(0.0, 0.0, 1.0);
+        let h_length = h.length();
+
+        if h_length.approx_zero_ulps(4) {
+            return 0.0;
+        }
+
+        let k = if normal.normal.approx_zero() {
+            let n_dot_h = h.z / h_length;
+            if exp_is_one {
+                n_dot_h
+            } else {
+                n_dot_h.powf(specular_exponent)
+            }
+        } else {
+            let mut n = normal.normal * scale_factor;
+            n.x *= normal.factor.x;
+            n.y *= normal.factor.y;
+
+            let normal = Vector3::new(n.x, n.y, 1.0);
+
+            let n_dot_h = normal.dot(&h) / normal.length() / h_length;
+            if exp_is_one {
+                n_dot_h
+            } else {
+                n_dot_h.powf(specular_exponent)
+            }
+        };
+
+        specular_constant * k
+    }
+
+    let mut calc = |nx, ny, normal: Normal| {
+        match light_source {
+            LightSource::DistantLight(_) => {}
+            LightSource::PointLight(ref light) => {
+                let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
+                let origin = Vector3::new(light.x, light.y, light.z);
+                let v = origin - Vector3::new(nx as f32, ny as f32, nz);
+                light_vector = v.normalized().unwrap_or(v);
+            }
+            LightSource::SpotLight(ref light) => {
+                let nz = src.alpha_at(nx, ny) as f32 / 255.0 * surface_scale;
+                let origin = Vector3::new(light.x, light.y, light.z);
+                let v = origin - Vector3::new(nx as f32, ny as f32, nz);
+                light_vector = v.normalized().unwrap_or(v);
+            }
+        }
+
+        let light_color = light_color(&light_source, lighting_color, light_vector);
+        let factor = specular_factor(
+            normal,
+            light_vector,
+            specular_exponent,
+            specular_constant,
+            exp_is_one,
+            scale_factor,
+        );
+
+        let compute = |x| (f32_bound(0.0, x as f32 * factor, 255.0) + 0.5) as u8;
+
+        let r = compute(light_color.red);
+        let g = compute(light_color.green);
+        let b = compute(light_color.blue);
+        let a = calc_specular_alpha(r, g, b);
+
+        *dest.pixel_at_mut(nx, ny) = RGBA8 { b, g, r, a };
+    };
+
+    calc(0, 0, top_left_normal(src));
+    calc(width - 1, 0, top_right_normal(src));
+    calc(0, height - 1, bottom_left_normal(src));
+    calc(width - 1, height - 1, bottom_right_normal(src));
+
+    for x in 1..width - 1 {
+        calc(x, 0, top_row_normal(src, x));
+        calc(x, height - 1, bottom_row_normal(src, x));
+    }
+
+    for y in 1..height - 1 {
+        calc(0, y, left_column_normal(src, y));
+        calc(width - 1, y, right_column_normal(src, y));
+    }
+
+    for y in 1..height - 1 {
+        for x in 1..width - 1 {
+            calc(x, y, interior_normal(src, x, y));
+        }
+    }
 }
 
 fn apply(
@@ -486,4 +636,168 @@ fn calc_diffuse_alpha(_: u8, _: u8, _: u8) -> u8 {
 fn calc_specular_alpha(r: u8, g: u8, b: u8) -> u8 {
     use core::cmp::max;
     max(max(r, g), b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test that the optimized specular lighting produces bit-exact results
+    /// by comparing naive vs optimized implementations through the internal API.
+    /// Since SpecularLighting fields are pub(crate) in usvg, we parse SVGs to
+    /// create the filter, then extract and call both implementations.
+    #[test]
+    fn test_specular_optimized_vs_naive_bit_exact() {
+        let sizes: &[(u32, u32)] = &[(4, 4), (16, 16), (64, 64), (100, 100)];
+        let exponents: &[f32] = &[1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 128.0];
+
+        let light_configs: Vec<(&str, &str)> = vec![
+            (
+                "distant_45_45",
+                r#"<feDistantLight azimuth="45" elevation="45"/>"#,
+            ),
+            (
+                "distant_0_90",
+                r#"<feDistantLight azimuth="0" elevation="90"/>"#,
+            ),
+            (
+                "point_50_50_100",
+                r#"<fePointLight x="50" y="50" z="100"/>"#,
+            ),
+            ("point_0_0_50", r#"<fePointLight x="0" y="0" z="50"/>"#),
+            (
+                "spot_basic",
+                r#"<feSpotLight x="50" y="50" z="100" pointsAtX="128" pointsAtY="128" pointsAtZ="0"/>"#,
+            ),
+            (
+                "spot_cone",
+                r#"<feSpotLight x="25" y="25" z="200" pointsAtX="50" pointsAtY="50" pointsAtZ="0" specularExponent="10" limitingConeAngle="30"/>"#,
+            ),
+        ];
+
+        fn make_test_image(width: u32, height: u32) -> Vec<RGBA8> {
+            let len = (width * height) as usize;
+            (0..len)
+                .map(|i| {
+                    let v = ((i * 37 + 13) % 256) as u8;
+                    RGBA8 {
+                        r: v,
+                        g: v,
+                        b: v,
+                        a: v,
+                    }
+                })
+                .collect()
+        }
+
+        for &(w, h) in sizes {
+            let src_data = make_test_image(w, h);
+
+            for &exp in exponents {
+                for &(name, light_xml) in &light_configs {
+                    let svg = format!(
+                        r##"<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}">
+  <defs>
+    <filter id="f">
+      <feSpecularLighting in="SourceGraphic" surfaceScale="1"
+        specularConstant="1" specularExponent="{exp}"
+        lighting-color="white" result="spec">
+        {light_xml}
+      </feSpecularLighting>
+    </filter>
+  </defs>
+  <rect width="{w}" height="{h}" fill="gray" filter="url(#f)"/>
+</svg>"##,
+                    );
+
+                    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+
+                    // Extract the SpecularLighting from the parsed tree.
+                    // Walk the tree to find the filter with specular lighting.
+                    let mut found = false;
+                    for node in tree.root().children() {
+                        if let usvg::Node::Group(group) = node {
+                            for filter in group.filters() {
+                                for primitive in filter.primitives() {
+                                    if let usvg::filter::Kind::SpecularLighting(fe) =
+                                        primitive.kind()
+                                    {
+                                        let light_source = fe.light_source();
+
+                                        // Run naive
+                                        let mut naive_dest = vec![
+                                            RGBA8 {
+                                                r: 0,
+                                                g: 0,
+                                                b: 0,
+                                                a: 0
+                                            };
+                                            (w * h) as usize
+                                        ];
+                                        specular_lighting_naive(
+                                            fe,
+                                            light_source,
+                                            ImageRef::new(w, h, &src_data),
+                                            ImageRefMut::new(w, h, &mut naive_dest),
+                                        );
+
+                                        // Run optimized
+                                        let mut opt_dest = vec![
+                                            RGBA8 {
+                                                r: 0,
+                                                g: 0,
+                                                b: 0,
+                                                a: 0
+                                            };
+                                            (w * h) as usize
+                                        ];
+                                        specular_lighting_optimized(
+                                            fe,
+                                            light_source,
+                                            ImageRef::new(w, h, &src_data),
+                                            ImageRefMut::new(w, h, &mut opt_dest),
+                                        );
+
+                                        // Compare byte-for-byte
+                                        for (idx, (n, o)) in
+                                            naive_dest.iter().zip(opt_dest.iter()).enumerate()
+                                        {
+                                            assert!(
+                                                n.r == o.r
+                                                    && n.g == o.g
+                                                    && n.b == o.b
+                                                    && n.a == o.a,
+                                                "Mismatch at pixel {} for {}x{} exp={} light={}: \
+                                                 naive=({},{},{},{}) opt=({},{},{},{})",
+                                                idx,
+                                                w,
+                                                h,
+                                                exp,
+                                                name,
+                                                n.r,
+                                                n.g,
+                                                n.b,
+                                                n.a,
+                                                o.r,
+                                                o.g,
+                                                o.b,
+                                                o.a,
+                                            );
+                                        }
+
+                                        found = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    assert!(
+                        found,
+                        "Failed to find specular lighting for {}x{} exp={} light={}",
+                        w, h, exp, name
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Devirtualize the light source dispatch by matching on the light type once per filter invocation rather than per pixel, allowing the compiler to inline and optimize each light path independently
- Hoist loop-invariant light properties (direction vector, position, cone parameters) out of the per-pixel loop so they are computed once and passed as local values
- Reduces dynamic dispatch overhead and enables LLVM to keep hot values in registers across the inner loop

## Benchmark Results

| Metric          | Value     |
|-----------------|-----------|
| Average speedup | **1.16x** |
| Maximum speedup | **1.25x** |

## Test Results

All 1723/1723 integration tests pass (`cargo test --release -p resvg --test integration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)