### PR TITLE
usvg/parser: fix width/height computation when only one is specified

### DIFF
--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -540,7 +540,16 @@ fn resolve_svg_size(svg: &SvgNode, opt: &Options) -> (Result<Size, Error>, bool)
             svg.convert_user_length(AId::Height, &state, def)
         };
 
-        Size::from_wh(w, h)
+        // If only one of height/width is not specified, its value should be
+        // computed from the other and the viewbox' aspect ratio.
+        match (
+            svg.attribute::<Length>(AId::Width),
+            svg.attribute::<Length>(AId::Height),
+        ) {
+            (Some(_), None) => Size::from_wh(w, vbox.height() * w / vbox.width()),
+            (None, Some(_)) => Size::from_wh(vbox.width() * h / vbox.height(), h),
+            (_, _) => Size::from_wh(w, h),
+        }
     } else {
         Size::from_wh(
             svg.convert_user_length(AId::Width, &state, def),

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -540,8 +540,8 @@ fn resolve_svg_size(svg: &SvgNode, opt: &Options) -> (Result<Size, Error>, bool)
             svg.convert_user_length(AId::Height, &state, def)
         };
 
-        // If only one of height/width is not specified, its value should be
-        // computed from the other and the viewbox' aspect ratio.
+        // If exactly one of width and height is specified, compute the missing
+        // dimension from the specified one and the viewBox aspect ratio.
         match (
             svg.attribute::<Length>(AId::Width),
             svg.attribute::<Length>(AId::Height),

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -218,6 +218,34 @@ fn size_detection_5() {
 }
 
 #[test]
+fn size_detection_6() {
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10' width='30'/>";
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    assert_eq!(tree.size(), usvg::Size::from_wh(30.0, 30.0).unwrap());
+}
+
+#[test]
+fn size_detection_7() {
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 20' width='30'/>";
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    assert_eq!(tree.size(), usvg::Size::from_wh(30.0, 60.0).unwrap());
+}
+
+#[test]
+fn size_detection_8() {
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10' height='30'/>";
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    assert_eq!(tree.size(), usvg::Size::from_wh(30.0, 30.0).unwrap());
+}
+
+#[test]
+fn size_detection_9() {
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 20' height='30'/>";
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    assert_eq!(tree.size(), usvg::Size::from_wh(15.0, 30.0).unwrap());
+}
+
+#[test]
 fn invalid_size_1() {
     let svg = "<svg width='0' height='0' viewBox='0 0 10 20' xmlns='http://www.w3.org/2000/svg'/>";
     let result = usvg::Tree::from_str(&svg, &usvg::Options::default());


### PR DESCRIPTION
In case only one of the height/width attributes are set and we have a viewBox, we currently report an incorrect size: the height/width that is set and 100% of the viewbox's attribute for the other attribute.

This is incorrect, and we should instead compute the missing attribute value from the specified one and the viewBox' aspect ratio, like was done by https://github.com/linebender/resvg/pull/715.

I have validated that this fixes servo's
   https://github.com/servo/servo/issues/41273
