### PR TITLE
Handle non-finite values in `f32_bound`

### DIFF
--- a/crates/resvg/src/filter/mod.rs
+++ b/crates/resvg/src/filter/mod.rs
@@ -241,15 +241,15 @@ fn from_linear_rgb(data: &mut [RGBA8]) {
 #[inline]
 fn f32_bound(min: f32, val: f32, max: f32) -> f32 {
     debug_assert!(min.is_finite());
-    debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
 
     if val > max {
         max
-    } else if val < min {
-        min
-    } else {
+    } else if val >= min {
         val
+    } else {
+        // Catches `val < min` as well as a NaN `val`.
+        min
     }
 }
 

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -177,14 +177,14 @@ pub fn decompress_svgz(data: &[u8]) -> Result<Vec<u8>, Error> {
 #[inline]
 pub(crate) fn f32_bound(min: f32, val: f32, max: f32) -> f32 {
     debug_assert!(min.is_finite());
-    debug_assert!(val.is_finite());
     debug_assert!(max.is_finite());
 
     if val > max {
         max
-    } else if val < min {
-        min
-    } else {
+    } else if val >= min {
         val
+    } else {
+        // Catches `val < min` as well as a NaN `val`.
+        min
     }
 }

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -5,6 +5,16 @@ use tiny_skia_path::Rect;
 use usvg::Color;
 
 #[test]
+fn gradient_stop_offset_overflowing_f32() {
+    // `4e38` overflows f32 to infinity; parsing must not panic.
+    let svg = "<svg xmlns='http://www.w3.org/2000/svg'>\
+        <defs><linearGradient id='g'><stop offset='4e38'/></linearGradient></defs>\
+        <rect width='1' height='1' fill='url(#g)'/>\
+    </svg>";
+    assert!(usvg::Tree::from_str(svg, &usvg::Options::default()).is_ok());
+}
+
+#[test]
 fn clippath_with_invalid_child() {
     let svg = "
     <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'>


### PR DESCRIPTION
`f32_bound` used `debug_assert!(val.is_finite())`, which panics on infinite or NaN values that are reachable from untrusted SVG input (e.g. a gradient `stop` with `offset="4e38"`, which overflows to `f32::INFINITY`). The check now folds `NaN` and out-of-range values to `min` like the existing comparison chain already does for infinities. Closes #1042.