### PR TITLE
Add --query-bbox

### DIFF
--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -41,7 +41,7 @@ fn process() -> Result<(), String> {
     // Do not print warning during the ID querying.
     //
     // Some crates still can print to stdout/stderr, but we can't do anything about it.
-    if !(args.query_all || args.quiet) {
+    if !(args.query_all || args.query_bbox || args.quiet) {
         if let Ok(()) = log::set_logger(&LOGGER) {
             log::set_max_level(log::LevelFilter::Warn);
         }
@@ -97,6 +97,9 @@ fn process() -> Result<(), String> {
 
     if args.query_all {
         return query_all(&tree);
+    }
+    if args.query_bbox {
+        return query_bbox(&tree);
     }
 
     // Render.
@@ -200,6 +203,7 @@ OPTIONS:
 
 
   --query-all                   Queries all valid SVG ids with bounding boxes
+  --query-bbox                  Queries document bounding box
   --export-id ID                Renders an object only with a specified ID
   --export-area-page            Use an image size instead of an object size during ID exporting
 
@@ -242,6 +246,7 @@ struct CliArgs {
     style_sheet: Option<path::PathBuf>,
 
     query_all: bool,
+    query_bbox: bool,
     export_id: Option<String>,
     export_area_page: bool,
 
@@ -305,6 +310,7 @@ fn collect_args() -> Result<CliArgs, pico_args::Error> {
         list_fonts: input.contains("--list-fonts"),
 
         query_all: input.contains("--query-all"),
+        query_bbox: input.contains("--query-bbox"),
         export_id: input.opt_value_from_str("--export-id")?,
         export_area_page: input.contains("--export-area-page"),
 
@@ -458,6 +464,7 @@ struct Args {
     in_svg: InputFrom,
     out_png: Option<OutputTo>,
     query_all: bool,
+    query_bbox: bool,
     export_id: Option<String>,
     export_area_page: bool,
     export_area_drawing: bool,
@@ -504,8 +511,11 @@ fn parse_args() -> Result<Args, String> {
         (svg_from, out_png)
     };
 
-    if !args.query_all && out_png.is_none() {
+    if !args.query_all && !args.query_bbox && out_png.is_none() {
         return Err("<out-png> must be set".to_string());
+    }
+    if args.query_all && args.query_bbox {
+        return Err("--query-all and --query-bbox are mutually exclusive".to_string());
     }
 
     if in_svg == InputFrom::Stdin && args.resources_dir.is_none() {
@@ -584,6 +594,7 @@ fn parse_args() -> Result<Args, String> {
         in_svg,
         out_png,
         query_all: args.query_all,
+        query_bbox: args.query_bbox,
         export_id,
         export_area_page: args.export_area_page,
         export_area_drawing: args.export_area_drawing,
@@ -640,22 +651,15 @@ fn query_all_impl(parent: &usvg::Group) -> usize {
 
         count += 1;
 
-        fn round_len(v: f32) -> f32 {
-            (v * 1000.0).round() / 1000.0
-        }
-
-        let bbox = node
-            .abs_layer_bounding_box()
-            .map(|r| r.to_rect())
-            .unwrap_or(node.abs_bounding_box());
+        let bbox = get_node_bbox(node);
 
         println!(
             "{},{},{},{},{}",
             node.id(),
-            round_len(bbox.x()),
-            round_len(bbox.y()),
-            round_len(bbox.width()),
-            round_len(bbox.height())
+            bbox.x(),
+            bbox.y(),
+            bbox.width(),
+            bbox.height()
         );
 
         if let usvg::Node::Group(group) = node {
@@ -664,6 +668,37 @@ fn query_all_impl(parent: &usvg::Group) -> usize {
     }
 
     count
+}
+
+fn get_node_bbox(node: &usvg::Node) -> usvg::Rect {
+    let bbox = node
+        .abs_layer_bounding_box()
+        .map(|r| r.to_rect())
+        .unwrap_or(node.abs_bounding_box());
+
+    fn round_len(v: f32) -> f32 {
+        (v * 1000.0).round() / 1000.0
+    }
+
+    usvg::Rect::from_xywh(
+        round_len(bbox.x()),
+        round_len(bbox.y()),
+        round_len(bbox.width()),
+        round_len(bbox.height()),
+    )
+    .expect("rounding should not yield invalid rect")
+}
+
+fn query_bbox(tree: &usvg::Tree) -> Result<(), String> {
+    let bbox = get_node_bbox(&usvg::Node::Group(Box::new(tree.root().clone())));
+    println!(
+        "{},{},{},{}",
+        bbox.x(),
+        bbox.y(),
+        bbox.width(),
+        bbox.height()
+    );
+    Ok(())
 }
 
 fn render_svg(args: &Args, tree: &usvg::Tree) -> Result<tiny_skia::Pixmap, String> {


### PR DESCRIPTION
Queries the document bounding box. This can be useful from scripts, e.g. to crop the image without rasterizing it.