### PR TITLE
Fix y-axis offset in feSpotLight `transform_light_source`

### DIFF
--- a/crates/resvg/src/filter/mod.rs
+++ b/crates/resvg/src/filter/mod.rs
@@ -1076,13 +1076,13 @@ fn transform_light_source(
             let mut point = tiny_skia::Point::from_xy(light.x, light.y);
             ts.map_point(&mut point);
             light.x = point.x - region.x() as f32;
-            light.y = point.y - region.x() as f32;
+            light.y = point.y - region.y() as f32;
             light.z *= sz;
 
             let mut point = tiny_skia::Point::from_xy(light.points_at_x, light.points_at_y);
             ts.map_point(&mut point);
             light.points_at_x = point.x - region.x() as f32;
-            light.points_at_y = point.y - region.x() as f32;
+            light.points_at_y = point.y - region.y() as f32;
             light.points_at_z *= sz;
         }
     }


### PR DESCRIPTION
`transform_light_source` was subtracting `region.x()` from the y-component of both `light.y` and `light.points_at_y` in the `SpotLight` branch (`crates/resvg/src/filter/mod.rs:1079, 1085`). Whenever the filter region origin has `x != y`, the spotlight is offset on the y axis by `region.x() - region.y()` pixels, producing mis-rendered specular/diffuse lighting.

The adjacent `PointLight` branch already uses `region.y()` for the y subtraction (line 1070), so the SpotLight branch is a copy-paste bug. This change brings SpotLight in line with PointLight and the SVG filter spec.

Existing filter tests (all 249) still pass; they happen to use filter regions anchored at the origin so the bug was not surfaced in the snapshot suite.