### PR TITLE
Fix fail to build

### DIFF
--- a/crates/resvg/src/filter/iir_blur.rs
+++ b/crates/resvg/src/filter/iir_blur.rs
@@ -26,7 +26,7 @@
 // TODO: Blurs right and bottom sides twice for some reason.
 
 use super::ImageRefMut;
-use rgb::ComponentSlice;
+use rgb::{ComponentSlice, ComponentBytes};
 
 struct BlurData {
     width: usize,
@@ -58,7 +58,7 @@ pub fn apply(sigma_x: f64, sigma_y: f64, src: ImageRefMut) {
         steps: 4,
     };
 
-    let data = src.data.as_mut_slice();
+    let data = src.data.as_mut_slice().as_bytes_mut();
     gaussian_channel(data, &d, 0, buf);
     gaussian_channel(data, &d, 1, buf);
     gaussian_channel(data, &d, 2, buf);


### PR DESCRIPTION
see https://github.com/wayvr-org/wayvr/issues/532

```
error[E0308]: mismatched types
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:62:22
   |
62 |     gaussian_channel(data, &d, 0, buf);
   |     ---------------- ^^^^ expected `&mut [u8]`, found `&mut [Rgba<u8>]`
   |     |
   |     arguments to this function are incorrect
   |
   = note: expected mutable reference `&mut [u8]`
              found mutable reference `&mut [RGBA<u8>]`
note: function defined here
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:68:4
   |
68 | fn gaussian_channel(data: &mut [u8], d: &BlurData, channel: usize, buf: &mut [f64]) {
   |    ^^^^^^^^^^^^^^^^ ---------------

error[E0308]: mismatched types
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:63:22
   |
63 |     gaussian_channel(data, &d, 1, buf);
   |     ---------------- ^^^^ expected `&mut [u8]`, found `&mut [Rgba<u8>]`
   |     |
   |     arguments to this function are incorrect
   |
   = note: expected mutable reference `&mut [u8]`
              found mutable reference `&mut [RGBA<u8>]`
note: function defined here
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.46.0/src/filter/iir_blur.rs:68:4
   |
68 | fn gaussian_channel(data: &mut [u8], d: &BlurData, channel: usize, buf: &mut [f64]) {
   |    ^^^^^^^^^^^^^^^^ ---------------

error[E0308]: mismatched types
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:64:22
   |
64 |     gaussian_channel(data, &d, 2, buf);
   |     ---------------- ^^^^ expected `&mut [u8]`, found `&mut [Rgba<u8>]`
   |     |
   |     arguments to this function are incorrect
   |
   = note: expected mutable reference `&mut [u8]`
              found mutable reference `&mut [RGBA<u8>]`
note: function defined here
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:68:4
   |
68 | fn gaussian_channel(data: &mut [u8], d: &BlurData, channel: usize, buf: &mut [f64]) {
   |    ^^^^^^^^^^^^^^^^ ---------------

error[E0308]: mismatched types
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:65:22
   |
65 |     gaussian_channel(data, &d, 3, buf);
   |     ---------------- ^^^^ expected `&mut [u8]`, found `&mut [Rgba<u8>]`
   |     |
   |     arguments to this function are incorrect
   |
   = note: expected mutable reference `&mut [u8]`
              found mutable reference `&mut [RGBA<u8>]`
note: function defined here
  --> /home/radiant/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/resvg-0.45.1/src/filter/iir_blur.rs:68:4
   |
68 | fn gaussian_channel(data: &mut [u8], d: &BlurData, channel: usize, buf: &mut [f64]) {
   |    ^^^^^^^^^^^^^^^^ ---------------
   ```

A pull request must contain a meaningful improvement to the project.
