### PR TITLE
Fix nested svg transform being applied twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This changelog also contains important changes in dependencies.
 
 This release has an MSRV of 1.87.0 for `usvg` and `resvg` and the C API.
 
+### Fixed
+- A `transform` (and other group properties like `opacity`) on a nested `svg`
+  element was applied twice, because the element was wrapped in a redundant group.
+  Nested `svg` is now handled like `use`.
+
 ## [0.47.0] 2026-02-05
 
 This release has an MSRV of 1.87.0 for `usvg` and `resvg` and the C API.

--- a/crates/usvg/src/parser/converter.rs
+++ b/crates/usvg/src/parser/converter.rs
@@ -598,6 +598,16 @@ pub(crate) fn convert_element(node: SvgNode, state: &State, cache: &mut Cache, p
         return;
     }
 
+    // A nested `svg` is handled just like `use`: it must not be wrapped in an
+    // additional `convert_group`, otherwise its `transform` (and other group
+    // properties) would be applied twice, since `convert_svg` already creates its
+    // own group. The outermost `svg` (no parent element) is intentionally not
+    // handled here - it's processed directly in `convert_doc`.
+    if tag_name == EId::Svg && node.parent_element().is_some() {
+        super::use_node::convert_svg(node, state, cache, parent);
+        return;
+    }
+
     if let Some(g) = convert_group(node, state, false, cache, parent, &|cache, g| {
         convert_element_impl(tag_name, node, state, cache, g);
     }) {
@@ -635,12 +645,10 @@ fn convert_element_impl(
             }
         }
         EId::Svg => {
-            if node.parent_element().is_some() {
-                super::use_node::convert_svg(node, state, cache, parent);
-            } else {
-                // Skip root `svg`.
-                convert_children(node, state, cache, parent);
-            }
+            // Only the outermost `svg` reaches this point; nested `svg` elements are
+            // handled earlier in `convert_element`. The root `svg` itself is skipped
+            // and only its children are converted.
+            convert_children(node, state, cache, parent);
         }
         EId::G => {
             convert_children(node, state, cache, parent);

--- a/crates/usvg/tests/parser.rs
+++ b/crates/usvg/tests/parser.rs
@@ -601,3 +601,55 @@ fn flattened_text_should_inherit_absolute_transform() {
         path.abs_bounding_box()
     );
 }
+
+// A nested `svg` element's `transform` must be applied exactly once, not doubled.
+// Regression test for the bug found while fixing
+// https://github.com/linebender/resvg/issues/899
+#[test]
+fn nested_svg_transform_applied_once() {
+    // Accumulate the relative transforms down to the first path. This is what the
+    // renderer effectively does, so it's the rendering-relevant value.
+    fn accumulated_path_transform(
+        group: &usvg::Group,
+        acc: usvg::Transform,
+    ) -> Option<usvg::Transform> {
+        for node in group.children() {
+            match node {
+                usvg::Node::Path(_) => return Some(acc),
+                usvg::Node::Group(g) => {
+                    if let Some(t) = accumulated_path_transform(g, acc.pre_concat(g.transform())) {
+                        return Some(t);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    // `transform` only (overflow visible, no clip group).
+    let svg = "
+    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+        <svg transform='translate(10, 20)' width='50' height='50' overflow='visible'>
+            <path d='M 0 0 L 10 10'/>
+        </svg>
+    </svg>
+    ";
+    let tree = usvg::Tree::from_str(&svg, &usvg::Options::default()).unwrap();
+    let ts = accumulated_path_transform(tree.root(), usvg::Transform::default())
+        .expect("path not found");
+    assert_eq!(ts, usvg::Transform::from_translate(10.0, 20.0));
+
+    // `transform` combined with the default `overflow: hidden` clip group.
+    let svg_clipped = "
+    <svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'>
+        <svg transform='translate(10, 20)' width='50' height='50'>
+            <path d='M 0 0 L 10 10'/>
+        </svg>
+    </svg>
+    ";
+    let tree = usvg::Tree::from_str(&svg_clipped, &usvg::Options::default()).unwrap();
+    let ts = accumulated_path_transform(tree.root(), usvg::Transform::default())
+        .expect("path not found");
+    assert_eq!(ts, usvg::Transform::from_translate(10.0, 20.0));
+}


### PR DESCRIPTION
Fixes #1066.

## Problem
A `transform` on a nested `<svg>` element was applied twice. The same happens to
other group properties (e.g. `opacity`). For example, a rect under
`<svg transform="translate(50,50)">` was rendered at (100,100) instead of (50,50).

## Cause
In `convert_element`, a nested `<svg>` was wrapped in a `convert_group` (which
reads the element's `transform`), and then `convert_svg` created its own group as
well — so the transform was applied in both. `<use>` does not have this problem
because it is routed to its handler and returns *before* the `convert_group` wrapper.

## Fix
Route a nested `<svg>` directly to `convert_svg` and return early, exactly like
`<use>`. The outermost `<svg>` (no parent element) is unaffected.

## Testing
- New regression test `nested_svg_transform_applied_once` (fails on `main` with
  `translate(20,40)`, passes with the fix as `translate(10,20)`).
- The full `usvg` test suite and all 1724 `resvg` render tests pass.

Generated by Claude