### PR TITLE
Reduce required dependencies with new feature gates

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -17,7 +17,9 @@ log = "0.4"
 resvg = { path = "../resvg", default-features = false }
 
 [features]
-default = ["text", "system-fonts", "memmap-fonts", "raster-images"]
+default = ["svgz", "text", "system-fonts", "memmap-fonts", "raster-images"]
+# Enables SVGZ decoding
+svgz = ["resvg/svgz"]
 # enables SVG Text support
 # adds around 500KiB to your binary
 text = ["resvg/text"]

--- a/crates/c-api/lib.rs
+++ b/crates/c-api/lib.rs
@@ -22,6 +22,8 @@ pub enum resvg_error {
     OK = 0,
     /// Only UTF-8 content are supported.
     NOT_AN_UTF8_STR,
+    /// `resvg` must be compiled with SVGZ decoding support.
+    SVGZ_UNSUPPORTED,
     /// Failed to open the provided file.
     FILE_OPEN_FAILED,
     /// Compressed SVG must use the GZip algorithm.
@@ -853,6 +855,7 @@ fn cstr_to_str(text: *const c_char) -> Option<&'static str> {
 fn convert_error(e: usvg::Error) -> resvg_error {
     match e {
         usvg::Error::NotAnUtf8Str => resvg_error::NOT_AN_UTF8_STR,
+        usvg::Error::SvgzFeatureNotEnabled => resvg_error::SVGZ_UNSUPPORTED,
         usvg::Error::MalformedGZip => resvg_error::MALFORMED_GZIP,
         usvg::Error::ElementsLimitReached => resvg_error::ELEMENTS_LIMIT_REACHED,
         usvg::Error::InvalidSize => resvg_error::INVALID_SIZE,

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -12,7 +12,7 @@ workspace = "../.."
 
 [[bin]]
 name = "resvg"
-required-features = ["text", "system-fonts", "memmap-fonts"]
+required-features = ["svgz", "text", "system-fonts", "memmap-fonts"]
 
 [dependencies]
 gif = { version = "0.14.1", optional = true }
@@ -30,7 +30,9 @@ once_cell = "1.21"
 png = "0.18.0"
 
 [features]
-default = ["text", "system-fonts", "memmap-fonts", "raster-images"]
+default = ["svgz", "text", "system-fonts", "memmap-fonts", "raster-images"]
+# Enables SVGZ decoding
+svgz = ["usvg/svgz"]
 # Enables SVG Text support.
 # Adds around 400KiB to your binary.
 text = ["usvg/text"]

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -15,7 +15,7 @@ workspace = "../.."
 
 [[bin]]
 name = "usvg"
-required-features = ["text", "system-fonts", "memmap-fonts", "writer"]
+required-features = ["svgz", "text", "system-fonts", "memmap-fonts", "writer"]
 
 [dependencies]
 base64 = { version = "0.22", optional = true } # for embedded images
@@ -28,7 +28,7 @@ xmlwriter = { version = "0.1", optional = true }
 
 # parser
 data-url = "0.3" # for href parsing
-flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] } # SVGZ decoding
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"], optional = true } # SVGZ decoding
 imagesize = "0.14.0" # raster images size detection
 kurbo = "0.13.0" # Bezier curves utils
 roxmltree = "0.21.1"
@@ -49,7 +49,9 @@ unicode-vo = { version = "0.1", optional = true }
 once_cell = "1.21"
 
 [features]
-default = ["text", "system-fonts", "memmap-fonts", "writer"]
+default = ["svgz", "text", "system-fonts", "memmap-fonts", "writer"]
+# Enables SVGZ decoding
+svgz = ["flate2"]
 # Enables text-to-path conversion support.
 # Adds around 400KiB to your binary.
 text = ["fontdb", "rustybuzz", "ttf-parser", "unicode-bidi", "unicode-script", "unicode-vo", "writer"]

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -15,16 +15,16 @@ workspace = "../.."
 
 [[bin]]
 name = "usvg"
-required-features = ["text", "system-fonts", "memmap-fonts"]
+required-features = ["text", "system-fonts", "memmap-fonts", "writer"]
 
 [dependencies]
-base64 = "0.22" # for embedded images
+base64 = { version = "0.22", optional = true } # for embedded images
 log = "0.4"
 pico-args = { version = "0.5", features = ["eq-separator"] }
 strict-num = "0.1.1"
 svgtypes = "0.16.1"
 tiny-skia-path = "0.12.0"
-xmlwriter = "0.1"
+xmlwriter = { version = "0.1", optional = true }
 
 # parser
 data-url = "0.3" # for href parsing
@@ -49,11 +49,13 @@ unicode-vo = { version = "0.1", optional = true }
 once_cell = "1.21"
 
 [features]
-default = ["text", "system-fonts", "memmap-fonts"]
+default = ["text", "system-fonts", "memmap-fonts", "writer"]
 # Enables text-to-path conversion support.
 # Adds around 400KiB to your binary.
-text = ["fontdb", "rustybuzz", "ttf-parser", "unicode-bidi", "unicode-script", "unicode-vo"]
+text = ["fontdb", "rustybuzz", "ttf-parser", "unicode-bidi", "unicode-script", "unicode-vo", "writer"]
 # Enables system fonts loading.
 system-fonts = ["fontdb/fs", "fontdb/fontconfig"]
 # Enables font files memmaping for faster loading.
 memmap-fonts = ["fontdb/memmap"]
+# Enables converting trees back to SVG.
+writer = ["xmlwriter", "base64"]

--- a/crates/usvg/src/lib.rs
+++ b/crates/usvg/src/lib.rs
@@ -55,6 +55,7 @@ mod parser;
 #[cfg(feature = "text")]
 mod text;
 mod tree;
+#[cfg(feature = "writer")]
 mod writer;
 
 pub use parser::*;
@@ -67,5 +68,7 @@ pub use roxmltree;
 #[cfg(feature = "text")]
 pub use fontdb;
 
+#[cfg(feature = "writer")]
 pub use writer::WriteOptions;
+#[cfg(feature = "writer")]
 pub use xmlwriter::Indent;

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -22,6 +22,7 @@ mod text;
 pub(crate) use converter::Cache;
 pub use image::{ImageHrefDataResolverFn, ImageHrefResolver, ImageHrefStringResolverFn};
 pub use options::Options;
+#[cfg(feature = "writer")]
 pub(crate) use svgtree::{AId, EId};
 
 /// List of all errors.

--- a/crates/usvg/src/parser/mod.rs
+++ b/crates/usvg/src/parser/mod.rs
@@ -31,6 +31,9 @@ pub enum Error {
     /// Only UTF-8 content are supported.
     NotAnUtf8Str,
 
+    /// `svgz` feature is required to parse SVGZ data.
+    SvgzFeatureNotEnabled,
+
     /// Compressed SVG must use the GZip algorithm.
     MalformedGZip,
 
@@ -59,6 +62,9 @@ impl std::fmt::Display for Error {
         match *self {
             Error::NotAnUtf8Str => {
                 write!(f, "provided data has not an UTF-8 encoding")
+            }
+            Self::SvgzFeatureNotEnabled => {
+                write!(f, "enable svgz cargo feature to decode SVGZ data")
             }
             Error::MalformedGZip => {
                 write!(f, "provided data has a malformed GZip content")
@@ -98,9 +104,15 @@ impl crate::Tree {
     /// Can contain an SVG string or a gzip compressed data.
     pub fn from_data(data: &[u8], opt: &Options) -> Result<Self, Error> {
         if data.starts_with(&[0x1f, 0x8b]) {
-            let data = decompress_svgz(data)?;
-            let text = std::str::from_utf8(&data).map_err(|_| Error::NotAnUtf8Str)?;
-            Self::from_str(text, opt)
+            #[cfg(feature = "svgz")]
+            {
+                let data = decompress_svgz(data)?;
+                let text = std::str::from_utf8(&data).map_err(|_| Error::NotAnUtf8Str)?;
+                Self::from_str(text, opt)
+            }
+
+            #[cfg(not(feature = "svgz"))]
+            Err(Error::SvgzFeatureNotEnabled)
         } else {
             let text = std::str::from_utf8(data).map_err(|_| Error::NotAnUtf8Str)?;
             Self::from_str(text, opt)
@@ -164,6 +176,7 @@ impl crate::Tree {
 }
 
 /// Decompresses an SVGZ file.
+#[cfg(feature = "svgz")]
 pub fn decompress_svgz(data: &[u8]) -> Result<Vec<u8>, Error> {
     use std::io::Read;
 


### PR DESCRIPTION
Kia ora!

This is a small modification to `usvg`'s features to reduce the size of the dependency tree for the common (imo) use case of a plain SVG parsing/simplification library.

Hopefully I'm not jumping the gun by going straight to a PR, but I thought it would be more helpful than filing an issue and making you guys do it :)

This does three things (broken into three commits):
 - Move the dependencies needed for writing SVG strings behind a new default `writer` feature. As some text functions seem to require SVG writing, the `text` feature also requires `writer`.
 - Move `pico-args` behind a new `cli` feature. This seems to only be needed by the binary, but in the interest of caution and not making any breaking changes for default users, I enabled `cli` by default too. Let me know if you'd rather leave this out of the default features.
 - Move `flate2` behind a new `svgz` feature. I've made attempting to parse SVGZ data with the feature disabled an `Error` variant, but it could just as easily be an assert or panic!/unimplemented! if preferred. This also needs a corresponding `resvg` feature following the same pattern and handling in the C api crate. Let me know if this should be handled differently by the C api.

All in all there should be no changes to any consumers of the crate(s) apart for a significant reduction in dependency count and compile time for some!

Cheers and thanks for all the great work!