### PR TITLE
Upgrade `strict-num` and `base64` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
 
 [[package]]
 name = "bitflags"
@@ -624,6 +624,12 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strict-num"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290fd5eab900654f4c270bc1cfaeb0f2c17b6851fa448fc22e1778dec105ac68"
 dependencies = [
  "float-cmp",
 ]
@@ -672,7 +678,7 @@ checksum = "edca365c3faccca67d06593c5980fa6c57687de727a03131735bb85f01fdeeb9"
 dependencies = [
  "arrayref",
  "bytemuck",
- "strict-num",
+ "strict-num 0.1.1",
 ]
 
 [[package]]
@@ -732,7 +738,7 @@ dependencies = [
  "simplecss",
  "siphasher 1.0.3",
  "skrifa",
- "strict-num",
+ "strict-num 0.2.0",
  "svgtypes",
  "tiny-skia-path",
  "unicode-bidi",

--- a/crates/usvg/Cargo.toml
+++ b/crates/usvg/Cargo.toml
@@ -18,10 +18,10 @@ name = "usvg"
 required-features = ["svgz", "text", "system-fonts", "memmap-fonts", "writer"]
 
 [dependencies]
-base64 = { version = "0.22", optional = true } # for embedded images
+base64 = { version = "0.23", optional = true } # for embedded images
 log = "0.4"
 pico-args = { version = "0.5", features = ["eq-separator"] }
-strict-num = "0.1.1"
+strict-num = "0.2.0"
 svgtypes = "0.16.1"
 tiny-skia-path = "0.12.0"
 xmlwriter = { version = "0.1", optional = true }


### PR DESCRIPTION
Version bumps:

- strict-num 0.1 -> 0.2
- base64 0.22 -> 0.23