### PR TITLE
Fix `as_mut_slice` future-compatibility warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
 name = "resvg"
 version = "0.48.0"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -15,6 +15,7 @@ name = "resvg"
 required-features = ["svgz", "text", "system-fonts", "memmap-fonts"]
 
 [dependencies]
+bytemuck = "1.16"
 gif = { version = "0.14.1", optional = true }
 image-webp = { version = "0.2.4", optional = true }
 log = "0.4"

--- a/crates/resvg/src/filter/iir_blur.rs
+++ b/crates/resvg/src/filter/iir_blur.rs
@@ -26,7 +26,6 @@
 // TODO: Blurs right and bottom sides twice for some reason.
 
 use super::ImageRefMut;
-use rgb::ComponentSlice;
 
 struct BlurData {
     width: usize,
@@ -58,7 +57,7 @@ pub fn apply(sigma_x: f64, sigma_y: f64, src: ImageRefMut) {
         steps: 4,
     };
 
-    let data = ComponentSlice::as_mut_slice(src.data);
+    let data = bytemuck::cast_slice_mut(src.data);
     gaussian_channel(data, &d, 0, buf);
     gaussian_channel(data, &d, 1, buf);
     gaussian_channel(data, &d, 2, buf);


### PR DESCRIPTION
Switches to `bytemuck` as suggested in the deprecation warning. This is new as a direct dependency, but was already depended on transitively.