### PR TITLE
Update Windows release runner to `windows-latest`

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -87,7 +87,7 @@ jobs:
 
   release-windows:
     name: Release Windows
-    runs-on: windows-2019
+    runs-on: windows-latest
     needs: ["create-release"]
     steps:
       - name: Checkout


### PR DESCRIPTION
It seems as though windows-2019 has been deprecated (since github-actions failed to find a runner for it). To fix this, we should probably update to windows-latest.