### PR TITLE
Let a PNG declare the resolution it was rendered at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ This changelog also contains important changes in dependencies.
 
 ## [Unreleased]
 
+### Added
+
+- `resvg::encode_png_with_dpi` and `resvg::save_png_with_dpi`, which write a `pHYs` chunk
+  so that the PNG declares the resolution it is meant to be shown at. Without it a viewer
+  has to guess, and most guess 96 DPI, which shows an image rendered for print or a high
+  resolution display at the wrong physical size. The `resvg` CLI gained a `--png-dpi` flag.
+
 ## [0.48.1] 2026-08-02
 
 This release has an MSRV of 1.85.0 for `usvg` and `resvg` and the C API.

--- a/crates/resvg/Cargo.toml
+++ b/crates/resvg/Cargo.toml
@@ -18,6 +18,7 @@ required-features = ["svgz", "text", "system-fonts", "memmap-fonts"]
 bytemuck = "1.16"
 gif = { version = "0.14.1", optional = true }
 image-webp = { version = "0.2.4", optional = true }
+png = "0.18.0" # for the `pHYs` chunk, which tiny-skia does not write
 log = "0.4"
 pico-args = { version = "0.5", features = ["eq-separator"] }
 rgb = "0.8"
@@ -28,7 +29,6 @@ zune-jpeg = { version = "0.5.9", optional = true }
 
 [dev-dependencies]
 once_cell = "1.21"
-png = "0.18.0"
 
 [features]
 default = ["svgz", "text", "system-fonts", "memmap-fonts", "raster-images"]

--- a/crates/resvg/src/lib.rs
+++ b/crates/resvg/src/lib.rs
@@ -25,6 +25,70 @@ mod mask;
 mod path;
 mod render;
 
+/// Encodes a pixmap as a PNG that declares a physical resolution.
+///
+/// A plain PNG carries no resolution, so a viewer or a word processor has to
+/// guess one, and most guess 96 DPI. An image rendered for print or for a high
+/// resolution display then shows up at the wrong physical size. Writing the
+/// resolution into the `pHYs` chunk states the size the image is meant to be
+/// shown at.
+///
+/// `dpi` is the resolution of the pixmap itself, which is only the same as
+/// [`usvg::Options::dpi`] when the tree was rendered without scaling. Rendering
+/// twice as large also doubles the resolution of the result.
+///
+/// # Example
+///
+/// ```no_run
+/// # let tree = usvg::Tree::from_str("<svg/>", &usvg::Options::default()).unwrap();
+/// let size = tree.size().to_int_size();
+/// let mut pixmap = tiny_skia::Pixmap::new(size.width(), size.height()).unwrap();
+/// resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+/// let png = resvg::encode_png_with_dpi(pixmap.as_ref(), 300.0).unwrap();
+/// ```
+pub fn encode_png_with_dpi(
+    pixmap: tiny_skia::PixmapRef,
+    dpi: f32,
+) -> Result<Vec<u8>, png::EncodingError> {
+    // `pHYs` counts pixels per meter, and an inch is 0.0254 of one.
+    let pixels_per_meter = (dpi / 0.0254).round().max(0.0) as u32;
+
+    // A pixmap stores premultiplied pixels, while PNG wants straight alpha.
+    let mut data = Vec::with_capacity(pixmap.data().len());
+    for pixel in pixmap.pixels() {
+        let color = pixel.demultiply();
+        data.extend_from_slice(&[color.red(), color.green(), color.blue(), color.alpha()]);
+    }
+
+    let mut png_data = Vec::new();
+    let mut encoder = png::Encoder::new(&mut png_data, pixmap.width(), pixmap.height());
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_pixel_dims(Some(png::PixelDimensions {
+        xppu: pixels_per_meter,
+        yppu: pixels_per_meter,
+        unit: png::Unit::Meter,
+    }));
+    let mut writer = encoder.write_header()?;
+    writer.write_image_data(&data)?;
+    writer.finish()?;
+
+    Ok(png_data)
+}
+
+/// Saves a pixmap as a PNG file that declares a physical resolution.
+///
+/// See [`encode_png_with_dpi`].
+pub fn save_png_with_dpi<P: AsRef<std::path::Path>>(
+    pixmap: tiny_skia::PixmapRef,
+    path: P,
+    dpi: f32,
+) -> Result<(), png::EncodingError> {
+    let data = encode_png_with_dpi(pixmap, dpi)?;
+    std::fs::write(path, data)?;
+    Ok(())
+}
+
 /// Renders a tree onto the pixmap.
 ///
 /// `transform` will be used as a root transform.

--- a/crates/resvg/src/main.rs
+++ b/crates/resvg/src/main.rs
@@ -102,15 +102,25 @@ fn process() -> Result<(), String> {
     // Render.
     let img = render_svg(&args, &tree)?;
 
+    let png_dpi = args.raw_args.png_dpi.map(|dpi| dpi as f32);
+
     match args.out_png.unwrap() {
         OutputTo::Stdout => {
             use std::io::Write;
-            let buf = img.encode_png().map_err(|e| e.to_string())?;
+            let buf = match png_dpi {
+                Some(dpi) => resvg::encode_png_with_dpi(img.as_ref(), dpi),
+                None => img.encode_png(),
+            }
+            .map_err(|e| e.to_string())?;
             std::io::stdout().write_all(&buf).unwrap();
         }
         OutputTo::File(ref file) => {
             timed(args.perf, "Saving", || {
-                img.save_png(file).map_err(|e| e.to_string())
+                match png_dpi {
+                    Some(dpi) => resvg::save_png_with_dpi(img.as_ref(), file, dpi),
+                    None => img.save_png(file),
+                }
+                .map_err(|e| e.to_string())
             })?;
         }
     };
@@ -139,6 +149,12 @@ OPTIONS:
   -w, --width LENGTH            Sets the width in pixels
   -h, --height LENGTH           Sets the height in pixels
   -z, --zoom FACTOR             Zooms the image by a factor
+      --png-dpi DPI             Writes this resolution into the PNG, so that it is
+                                displayed and printed at the intended physical size.
+                                This is the resolution of the rendered image, which
+                                differs from '--dpi' when '--zoom', '--width' or
+                                '--height' scale the output
+                                [values: 10..4000 (inclusive)]
       --dpi DPI                 Sets the resolution
                                 [default: 96] [possible values: 10..4000 (inclusive)]
   --background COLOR            Sets the background color
@@ -220,6 +236,7 @@ struct CliArgs {
     height: Option<u32>,
     zoom: Option<f32>,
     dpi: u32,
+    png_dpi: Option<u32>,
     background: Option<svgtypes::Color>,
 
     languages: Vec<String>,
@@ -272,6 +289,7 @@ fn collect_args() -> Result<CliArgs, pico_args::Error> {
         height: input.opt_value_from_fn(["-h", "--height"], parse_length)?,
         zoom: input.opt_value_from_fn(["-z", "--zoom"], parse_zoom)?,
         dpi: input.opt_value_from_fn("--dpi", parse_dpi)?.unwrap_or(96),
+        png_dpi: input.opt_value_from_fn("--png-dpi", parse_dpi)?,
         background: input.opt_value_from_str("--background")?,
 
         languages: input

--- a/crates/resvg/tests/integration/main.rs
+++ b/crates/resvg/tests/integration/main.rs
@@ -15,6 +15,7 @@ use usvg::fontdb;
 mod render;
 
 mod extra;
+mod png_dpi;
 
 const IMAGE_SIZE: u32 = 300;
 

--- a/crates/resvg/tests/integration/png_dpi.rs
+++ b/crates/resvg/tests/integration/png_dpi.rs
@@ -1,0 +1,64 @@
+// Copyright 2026 the Resvg Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fn pixmap() -> tiny_skia::Pixmap {
+    let mut pixmap = tiny_skia::Pixmap::new(20, 10).unwrap();
+    pixmap.fill(tiny_skia::Color::from_rgba8(0, 128, 128, 128));
+    pixmap
+}
+
+/// Reads back what a PNG declares, in pixels per meter.
+fn pixel_dims(data: &[u8]) -> Option<png::PixelDimensions> {
+    let decoder = png::Decoder::new(std::io::Cursor::new(data));
+    let reader = decoder.read_info().unwrap();
+    reader.info().pixel_dims
+}
+
+#[test]
+fn writes_the_resolution() {
+    let data = resvg::encode_png_with_dpi(pixmap().as_ref(), 300.0).unwrap();
+    let dims = pixel_dims(&data).expect("no pHYs chunk");
+
+    // 300 dpi is 300 / 0.0254 pixels per meter, rounded to a whole pixel.
+    assert_eq!(dims.xppu, 11811);
+    assert_eq!(dims.yppu, 11811);
+    assert_eq!(dims.unit, png::Unit::Meter);
+}
+
+#[test]
+fn plain_encoding_declares_nothing() {
+    let data = pixmap().encode_png().unwrap();
+    assert!(pixel_dims(&data).is_none());
+}
+
+/// The added chunk must not change the image itself.
+#[test]
+fn keeps_the_pixels() {
+    let pixmap = pixmap();
+    let with_dpi = resvg::encode_png_with_dpi(pixmap.as_ref(), 300.0).unwrap();
+    let plain = pixmap.encode_png().unwrap();
+
+    let decode = |data: &[u8]| {
+        let mut reader = png::Decoder::new(std::io::Cursor::new(data.to_vec()))
+            .read_info()
+            .unwrap();
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
+        let info = reader.next_frame(&mut buf).unwrap();
+        buf.truncate(info.buffer_size());
+        buf
+    };
+
+    assert_eq!(decode(&with_dpi), decode(&plain));
+}
+
+#[test]
+fn saves_to_a_file() {
+    let dir = std::env::temp_dir().join("resvg-png-dpi-test");
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("dpi.png");
+
+    resvg::save_png_with_dpi(pixmap().as_ref(), &path, 96.0).unwrap();
+
+    let data = std::fs::read(&path).unwrap();
+    assert_eq!(pixel_dims(&data).unwrap().xppu, 3780);
+}


### PR DESCRIPTION
Adds `resvg::encode_png_with_dpi` and `resvg::save_png_with_dpi`, plus a `--png-dpi` flag
on the CLI.

### Why

A PNG without a `pHYs` chunk carries no resolution, so whatever opens it has to guess one,
and most guess 96 DPI. An image rendered for print or for a high resolution display then
shows up at the wrong physical size. This matters particularly for SVG output, since the
resolution is also what decides how large the text in the image ends up: rendering a
document at 300 DPI and then having it displayed as if it were 96 undoes exactly the
sizing the document asked for.

`tiny_skia::Pixmap::encode_png` writes no `pHYs` chunk and offers no way to add one, so
this cannot be done by the caller without re-encoding the image by hand.

### Which resolution

The value is the resolution of the rendered image, which is only the same as
`usvg::Options::dpi` when the tree was rendered without scaling. `--zoom`, `--width` and
`--height` all change it. Deriving it automatically would also have to take a position on
what an SVG user unit means physically, which `--dpi` and the CSS definition of an inch
disagree about for documents sized in `px`. The CLI therefore takes the value explicitly
rather than guessing, and the docs state what it refers to.

### Implementation

The pixel data is produced exactly as tiny-skia produces it, by demultiplying through its
`PremultipliedColorU8::demultiply` rather than repeating the arithmetic, so the two paths
cannot drift apart. `png` becomes a regular dependency of `resvg` instead of a
dev-dependency only; it is already in the tree through tiny-skia, and `png::EncodingError`
is already part of resvg's public API surface through tiny-skia's own signatures.

### Tests

Four tests: the chunk is written with the expected pixels-per-meter, a plain encoding
still declares nothing, the file-writing wrapper round-trips, and the decoded image is
byte for byte the same as the one from `Pixmap::encode_png`, so adding the chunk cannot
change the picture.